### PR TITLE
Add DOM callback props to all mui components

### DIFF
--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiAppBar.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiAppBar.scala
@@ -8,53 +8,135 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiAppBar(
-  key:                       js.UndefOr[String]                       = js.undefined,
-  ref:                       js.UndefOr[String]                       = js.undefined,
+  key:                       js.UndefOr[String]                             = js.undefined,
+  ref:                       js.UndefOr[String]                             = js.undefined,
   /* Applied to the app bar's root element.*/
-  className:                 js.UndefOr[String]                       = js.undefined,
+  className:                 js.UndefOr[String]                             = js.undefined,
   /* The classname of the icon on the left of the app bar.
   If you are using a stylesheet for your icons, enter the class name for the icon to be used here.*/
-  iconClassNameLeft:         js.UndefOr[String]                       = js.undefined,
+  iconClassNameLeft:         js.UndefOr[String]                             = js.undefined,
   /* Similiar to the iconClassNameLeft prop except that
   it applies to the icon displayed on the right of the app bar.*/
-  iconClassNameRight:        js.UndefOr[String]                       = js.undefined,
+  iconClassNameRight:        js.UndefOr[String]                             = js.undefined,
   /* The custom element to be displayed on the left side of the
   app bar such as an SvgIcon.*/
-  iconElementLeft:           js.UndefOr[ReactElement]                 = js.undefined,
+  iconElementLeft:           js.UndefOr[ReactElement]                       = js.undefined,
   /* Similiar to the iconElementLeft prop except that this element is displayed on the right of the app bar.*/
-  iconElementRight:          js.UndefOr[ReactElement]                 = js.undefined,
+  iconElementRight:          js.UndefOr[ReactElement]                       = js.undefined,
   /* Override the inline-styles of the element displayed on the left side of the app bar.*/
-  iconStyleLeft:             js.UndefOr[CssProperties]                = js.undefined,
+  iconStyleLeft:             js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the element displayed on the right side of the app bar.*/
-  iconStyleRight:            js.UndefOr[CssProperties]                = js.undefined,
+  iconStyleRight:            js.UndefOr[CssProperties]                      = js.undefined,
   /* Callback function for when the left icon is selected via a touch tap.*/
-  onLeftIconButtonTouchTap:  js.UndefOr[ReactTouchEventH => Callback] = js.undefined,
+  onLeftIconButtonTouchTap:  js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* Callback function for when the right icon is selected via a touch tap.*/
-  onRightIconButtonTouchTap: js.UndefOr[ReactTouchEventH => Callback] = js.undefined,
+  onRightIconButtonTouchTap: js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* Callback function for when the title text is selected via a touch tap.*/
-  onTitleTouchTap:           js.UndefOr[ReactTouchEventH => Callback] = js.undefined,
+  onTitleTouchTap:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* Determines whether or not to display the Menu icon next to the title.
   Setting this prop to false will hide the icon.*/
-  showMenuIconButton:        js.UndefOr[Boolean]                      = js.undefined,
+  showMenuIconButton:        js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                     js.UndefOr[CssProperties]                = js.undefined,
+  style:                     js.UndefOr[CssProperties]                      = js.undefined,
   /* The title to display on the app bar.*/
-  title:                     js.UndefOr[ReactNode]                    = js.undefined,
+  title:                     js.UndefOr[ReactNode]                          = js.undefined,
   /* Override the inline-styles of the app bar's title element.*/
-  titleStyle:                js.UndefOr[CssProperties]                = js.undefined,
+  titleStyle:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The zDepth of the component.
   The shadow of the app bar is also dependent on this property.*/
-  zDepth:                    js.UndefOr[ZDepth]                       = js.undefined,
+  zDepth:                    js.UndefOr[ZDepth]                             = js.undefined,
   /* Set to true to generate a circlular paper container.
   (Passed on to Paper)*/
-  circle:                    js.UndefOr[Boolean]                      = js.undefined,
+  circle:                    js.UndefOr[Boolean]                            = js.undefined,
   /* By default, the paper container will have a border radius.
   Set this to false to generate a container with sharp corners.
   (Passed on to Paper)*/
-  rounded:                   js.UndefOr[Boolean]                      = js.undefined,
+  rounded:                   js.UndefOr[Boolean]                            = js.undefined,
   /* Set to false to disable CSS transitions for the paper element.
   (Passed on to Paper)*/
-  transitionEnabled:         js.UndefOr[Boolean]                      = js.undefined){
+  transitionEnabled:         js.UndefOr[Boolean]                            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:            js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:      js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:          js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:                    js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:                  js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                   js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:          js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:        js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:       js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                    js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                     js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:             js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                    js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:                js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:                js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                    js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:                   js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                   js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:                 js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:                js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                   js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:               js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:               js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:                 js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                   js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                  js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                  js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                  js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:             js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:                js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:               js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:              js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                   js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be used to render a tab inside an app bar for instance.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiAutoComplete.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiAutoComplete.scala
@@ -145,7 +145,81 @@ case class MuiAutoComplete(
   underlineStyle:          js.UndefOr[CssProperties]                                         = js.undefined,
   /* The value of the text field.
   (Passed on to TextField)*/
-  value:                   js.UndefOr[String]                                                = js.undefined){
+  value:                   js.UndefOr[String]                                                = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:          js.UndefOr[ReactEventH => Callback]                               = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:    js.UndefOr[ReactEventH => Callback]                               = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:        js.UndefOr[ReactEventH => Callback]                               = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                 js.UndefOr[ReactMouseEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:        js.UndefOr[ReactCompositionEventH => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:      js.UndefOr[ReactCompositionEventH => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:     js.UndefOr[ReactCompositionEventH => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:           js.UndefOr[ReactEventH => Callback]                               = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                  js.UndefOr[ReactClipboardEventH => Callback]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                   js.UndefOr[ReactClipboardEventH => Callback]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:           js.UndefOr[ReactMouseEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                  js.UndefOr[ReactDragEventH => Callback]                           = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:               js.UndefOr[ReactDragEventH => Callback]                           = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:             js.UndefOr[ReactDragEventH => Callback]                           = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:              js.UndefOr[ReactDragEventH => Callback]                           = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:             js.UndefOr[ReactDragEventH => Callback]                           = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:              js.UndefOr[ReactDragEventH => Callback]                           = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:             js.UndefOr[ReactDragEventH => Callback]                           = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                  js.UndefOr[ReactDragEventH => Callback]                           = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                 js.UndefOr[ReactKeyboardEventH => Callback]                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:              js.UndefOr[ReactKeyboardEventH => Callback]                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                 js.UndefOr[ReactKeyboardEventH => Callback]                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:             js.UndefOr[ReactMouseEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:            js.UndefOr[ReactMouseEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:            js.UndefOr[ReactMouseEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:             js.UndefOr[ReactMouseEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:               js.UndefOr[ReactMouseEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                 js.UndefOr[ReactClipboardEventH => Callback]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                js.UndefOr[ReactUIEventH => Callback]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                js.UndefOr[ReactUIEventH => Callback]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                js.UndefOr[ReactEventH => Callback]                               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:           js.UndefOr[ReactTouchEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:              js.UndefOr[ReactTouchEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:             js.UndefOr[ReactTouchEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:            js.UndefOr[ReactTouchEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:         js.UndefOr[ReactTouchEventH => Callback]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                 js.UndefOr[ReactWheelEventH => Callback]                          = js.undefined){
   def apply(children: ReactNode*) = {
     val props = JSMacro[MuiAutoComplete](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.AutoComplete)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiAvatar.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiAvatar.scala
@@ -8,22 +8,104 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiAvatar(
-  key:             js.UndefOr[String]        = js.undefined,
-  ref:             js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* The backgroundColor of the avatar. Does not apply to image avatars.*/
-  backgroundColor: js.UndefOr[MuiColor]      = js.undefined,
+  backgroundColor:      js.UndefOr[MuiColor]                           = js.undefined,
   /* The css class name of the root `div` or `img` element.*/
-  className:       js.UndefOr[String]        = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* The icon or letter's color.*/
-  color:           js.UndefOr[MuiColor]      = js.undefined,
+  color:                js.UndefOr[MuiColor]                           = js.undefined,
   /* This is the SvgIcon or FontIcon to be used inside the avatar.*/
-  icon:            js.UndefOr[ReactElement]  = js.undefined,
+  icon:                 js.UndefOr[ReactElement]                       = js.undefined,
   /* This is the size of the avatar in pixels.*/
-  size:            js.UndefOr[Int]           = js.undefined,
+  size:                 js.UndefOr[Int]                                = js.undefined,
   /* If passed in, this component will render an img element. Otherwise, a div will be rendered.*/
-  src:             js.UndefOr[String]        = js.undefined,
+  src:                  js.UndefOr[String]                             = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:           js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be used, for instance, to render a letter inside the avatar.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiBadge.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiBadge.scala
@@ -8,20 +8,102 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiBadge(
-  key:          js.UndefOr[String]        = js.undefined,
-  ref:          js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* This is the content rendered within the badge.*/
-  badgeContent: ReactNode,
+  badgeContent:         ReactNode,
   /* Override the inline-styles of the badge element.*/
-  badgeStyle:   js.UndefOr[CssProperties] = js.undefined,
+  badgeStyle:           js.UndefOr[CssProperties]                      = js.undefined,
   /* The css class name of the root element.*/
-  className:    js.UndefOr[String]        = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* If true, the badge will use the primary badge colors.*/
-  primary:      js.UndefOr[Boolean]       = js.undefined,
+  primary:              js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the badge will use the secondary badge colors.*/
-  secondary:    js.UndefOr[Boolean]       = js.undefined,
+  secondary:            js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:        js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children The badge will be added relativelty to this node.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCard.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCard.scala
@@ -8,40 +8,122 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiCard(
-  key:                  js.UndefOr[String]              = js.undefined,
-  ref:                  js.UndefOr[String]              = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* Override the inline-styles of the container element.*/
-  containerStyle:       js.UndefOr[CssProperties]       = js.undefined,
+  containerStyle:       js.UndefOr[CssProperties]                      = js.undefined,
   /* If true, this card component is expandable. Can be set on any child of the `Card` component.*/
-  expandable:           js.UndefOr[Boolean]             = js.undefined,
+  expandable:           js.UndefOr[Boolean]                            = js.undefined,
   /* Whether this card is expanded.
   If `true` or `false` the component is controlled.
   if `null` the component is uncontrolled.*/
-  expanded:             js.UndefOr[Boolean]             = js.undefined,
+  expanded:             js.UndefOr[Boolean]                            = js.undefined,
   /* Whether this card is initially expanded.*/
-  initiallyExpanded:    js.UndefOr[Boolean]             = js.undefined,
+  initiallyExpanded:    js.UndefOr[Boolean]                            = js.undefined,
   /* Callback function fired when the `expandable` state of the card has changed.*/
-  onExpandChange:       js.UndefOr[Boolean => Callback] = js.undefined,
+  onExpandChange:       js.UndefOr[Boolean => Callback]                = js.undefined,
   /* If true, this card component will include a button to expand the card. `CardTitle`,
   `CardHeader` and `CardActions` implement `showExpandableButton`. Any child component
   of `Card` can implements `showExpandableButton` or forwards the property to a child
   component supporting it.*/
-  showExpandableButton: js.UndefOr[Boolean]             = js.undefined,
+  showExpandableButton: js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                js.UndefOr[CssProperties]       = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* Set to true to generate a circlular paper container.
   (Passed on to Paper)*/
-  circle:               js.UndefOr[Boolean]             = js.undefined,
+  circle:               js.UndefOr[Boolean]                            = js.undefined,
   /* By default, the paper container will have a border radius.
   Set this to false to generate a container with sharp corners.
   (Passed on to Paper)*/
-  rounded:              js.UndefOr[Boolean]             = js.undefined,
+  rounded:              js.UndefOr[Boolean]                            = js.undefined,
   /* Set to false to disable CSS transitions for the paper element.
   (Passed on to Paper)*/
-  transitionEnabled:    js.UndefOr[Boolean]             = js.undefined,
+  transitionEnabled:    js.UndefOr[Boolean]                            = js.undefined,
   /* This number represents the zDepth of the paper shadow.
   (Passed on to Paper)*/
-  zDepth:               js.UndefOr[ZDepth]              = js.undefined){
+  zDepth:               js.UndefOr[ZDepth]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be used to render elements inside the Card.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardActions.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardActions.scala
@@ -8,16 +8,98 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiCardActions(
-  key:                  js.UndefOr[String]        = js.undefined,
-  ref:                  js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* If true, a click on this card component expands the card.*/
-  actAsExpander:        js.UndefOr[Boolean]       = js.undefined,
+  actAsExpander:        js.UndefOr[Boolean]                            = js.undefined,
   /* If true, this card component is expandable.*/
-  expandable:           js.UndefOr[Boolean]       = js.undefined,
+  expandable:           js.UndefOr[Boolean]                            = js.undefined,
   /* If true, this card component will include a button to expand the card.*/
-  showExpandableButton: js.UndefOr[Boolean]       = js.undefined,
+  showExpandableButton: js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be used to render elements inside the Card Action.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardExpandable.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardExpandable.scala
@@ -8,11 +8,93 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiCardExpandable(
-  key:         js.UndefOr[String]        = js.undefined,
-  ref:         js.UndefOr[String]        = js.undefined,
-  expanded:    js.UndefOr[Boolean]       = js.undefined,
-  onExpanding: Callback,
-  style:       js.UndefOr[CssProperties] = js.undefined){
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
+  expanded:             js.UndefOr[Boolean]                            = js.undefined,
+  onExpanding:          Callback,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     val props = JSMacro[MuiCardExpandable](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.CardExpandable)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardHeader.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardHeader.scala
@@ -8,34 +8,116 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiCardHeader(
-  key:                  js.UndefOr[String]        = js.undefined,
-  ref:                  js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* If true, a click on this card component expands the card.*/
-  actAsExpander:        js.UndefOr[Boolean]       = js.undefined,
+  actAsExpander:        js.UndefOr[Boolean]                            = js.undefined,
   /* This is the [Avatar](/#/components/avatar) element to be displayed on the Card Header.
   If `avatar` is an `Avatar` or other element, it will be rendered.
   If `avatar` is a string, it will be used as the image `src` for an `Avatar`.*/
-  avatar:               js.UndefOr[ReactNode]     = js.undefined,
+  avatar:               js.UndefOr[ReactNode]                          = js.undefined,
   /* If true, this card component is expandable.*/
-  expandable:           js.UndefOr[Boolean]       = js.undefined,
+  expandable:           js.UndefOr[Boolean]                            = js.undefined,
   /* If true, this card component will include a button to expand the card.*/
-  showExpandableButton: js.UndefOr[Boolean]       = js.undefined,
+  showExpandableButton: js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                js.UndefOr[CssProperties] = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* Can be used to render a subtitle in Card Header.*/
-  subtitle:             js.UndefOr[ReactNode]     = js.undefined,
+  subtitle:             js.UndefOr[ReactNode]                          = js.undefined,
   /* Override the subtitle color.*/
-  subtitleColor:        js.UndefOr[MuiColor]      = js.undefined,
+  subtitleColor:        js.UndefOr[MuiColor]                           = js.undefined,
   /* Override the inline-styles of the subtitle.*/
-  subtitleStyle:        js.UndefOr[CssProperties] = js.undefined,
+  subtitleStyle:        js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the text.*/
-  textStyle:            js.UndefOr[CssProperties] = js.undefined,
+  textStyle:            js.UndefOr[CssProperties]                      = js.undefined,
   /* Can be used to render a title in Card Header.*/
-  title:                js.UndefOr[ReactNode]     = js.undefined,
+  title:                js.UndefOr[ReactNode]                          = js.undefined,
   /* Override the title color.*/
-  titleColor:           js.UndefOr[MuiColor]      = js.undefined,
+  titleColor:           js.UndefOr[MuiColor]                           = js.undefined,
   /* Override the inline-styles of the title.*/
-  titleStyle:           js.UndefOr[CssProperties] = js.undefined){
+  titleStyle:           js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be used to render elements inside the Card Header.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardMedia.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardMedia.scala
@@ -8,24 +8,106 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiCardMedia(
-  key:                   js.UndefOr[String]        = js.undefined,
-  ref:                   js.UndefOr[String]        = js.undefined,
+  key:                   js.UndefOr[String]                             = js.undefined,
+  ref:                   js.UndefOr[String]                             = js.undefined,
   /* If true, a click on this card component expands the card.*/
-  actAsExpander:         js.UndefOr[Boolean]       = js.undefined,
+  actAsExpander:         js.UndefOr[Boolean]                            = js.undefined,
   /* If true, this card component is expandable.*/
-  expandable:            js.UndefOr[Boolean]       = js.undefined,
+  expandable:            js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the Card Media.*/
-  mediaStyle:            js.UndefOr[CssProperties] = js.undefined,
+  mediaStyle:            js.UndefOr[CssProperties]                      = js.undefined,
   /* Can be used to render overlay element in Card Media.*/
-  overlay:               js.UndefOr[ReactNode]     = js.undefined,
+  overlay:               js.UndefOr[ReactNode]                          = js.undefined,
   /* Override the inline-styles of the overlay container.*/
-  overlayContainerStyle: js.UndefOr[CssProperties] = js.undefined,
+  overlayContainerStyle: js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the overlay content.*/
-  overlayContentStyle:   js.UndefOr[CssProperties] = js.undefined,
+  overlayContentStyle:   js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the overlay element.*/
-  overlayStyle:          js.UndefOr[CssProperties] = js.undefined,
+  overlayStyle:          js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                 js.UndefOr[CssProperties] = js.undefined){
+  style:                 js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:  js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:      js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:                js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:              js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:               js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:      js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:    js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:         js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                 js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:             js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:               js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:             js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:               js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:           js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:           js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:             js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:              js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:              js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:              js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:            js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:       js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:               js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be used to render elements inside the Card Media.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardText.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardText.scala
@@ -8,16 +8,98 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiCardText(
-  key:           js.UndefOr[String]        = js.undefined,
-  ref:           js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* If true, a click on this card component expands the card.*/
-  actAsExpander: js.UndefOr[Boolean]       = js.undefined,
+  actAsExpander:        js.UndefOr[Boolean]                            = js.undefined,
   /* Override the CardText color.*/
-  color:         js.UndefOr[MuiColor]      = js.undefined,
+  color:                js.UndefOr[MuiColor]                           = js.undefined,
   /* If true, this card component is expandable.*/
-  expandable:    js.UndefOr[Boolean]       = js.undefined,
+  expandable:           js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:         js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be used to render elements inside the Card Text.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardTitle.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCardTitle.scala
@@ -8,28 +8,110 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiCardTitle(
-  key:                  js.UndefOr[String]        = js.undefined,
-  ref:                  js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* If true, a click on this card component expands the card.*/
-  actAsExpander:        js.UndefOr[Boolean]       = js.undefined,
+  actAsExpander:        js.UndefOr[Boolean]                            = js.undefined,
   /* If true, this card component is expandable.*/
-  expandable:           js.UndefOr[Boolean]       = js.undefined,
+  expandable:           js.UndefOr[Boolean]                            = js.undefined,
   /* If true, this card component will include a button to expand the card.*/
-  showExpandableButton: js.UndefOr[Boolean]       = js.undefined,
+  showExpandableButton: js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                js.UndefOr[CssProperties] = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* Can be used to render a subtitle in the Card Title.*/
-  subtitle:             js.UndefOr[ReactNode]     = js.undefined,
+  subtitle:             js.UndefOr[ReactNode]                          = js.undefined,
   /* Override the subtitle color.*/
-  subtitleColor:        js.UndefOr[MuiColor]      = js.undefined,
+  subtitleColor:        js.UndefOr[MuiColor]                           = js.undefined,
   /* Override the inline-styles of the subtitle.*/
-  subtitleStyle:        js.UndefOr[CssProperties] = js.undefined,
+  subtitleStyle:        js.UndefOr[CssProperties]                      = js.undefined,
   /* Can be used to render a title in the Card Title.*/
-  title:                js.UndefOr[ReactNode]     = js.undefined,
+  title:                js.UndefOr[ReactNode]                          = js.undefined,
   /* Override the title color.*/
-  titleColor:           js.UndefOr[MuiColor]      = js.undefined,
+  titleColor:           js.UndefOr[MuiColor]                           = js.undefined,
   /* Override the inline-styles of the title.*/
-  titleStyle:           js.UndefOr[CssProperties] = js.undefined){
+  titleStyle:           js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be used to render elements inside the Card Title.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCheckBox.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCheckBox.scala
@@ -86,7 +86,75 @@ case class MuiCheckbox[T](
   /* (Passed on to EnhancedSwitch)*/
   trackStyle:           js.UndefOr[CssProperties]                      = js.undefined,
   /* (Passed on to EnhancedSwitch)*/
-  value:                js.UndefOr[T]                                  = js.undefined){
+  value:                js.UndefOr[T]                                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     implicit def evT(t: T): js.Any = t.asInstanceOf[js.Any]
     val props = JSMacro[MuiCheckbox[T]](this)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiChip.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiChip.scala
@@ -68,7 +68,67 @@ case class MuiChip(
   /* (Passed on to EnhancedButton)*/
   touchRippleOpacity:   js.UndefOr[Double]                                    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  `type`:               js.UndefOr[String]                                    = js.undefined){
+  `type`:               js.UndefOr[String]                                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]              = js.undefined){
   /**
    * @param children Used to render elements inside the Chip.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCircularProgress.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiCircularProgress.scala
@@ -8,25 +8,107 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiCircularProgress(
-  key:        js.UndefOr[String]                       = js.undefined,
-  ref:        js.UndefOr[MuiCircularProgressM => Unit] = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiCircularProgressM => Unit]       = js.undefined,
   /* Override the progress's color.*/
-  color:      js.UndefOr[MuiColor]                     = js.undefined,
+  color:                js.UndefOr[MuiColor]                           = js.undefined,
   /* Style for inner wrapper div.*/
-  innerStyle: js.UndefOr[CssProperties]                = js.undefined,
+  innerStyle:           js.UndefOr[CssProperties]                      = js.undefined,
   /* The max value of progress, only works in determinate mode.*/
-  max:        js.UndefOr[Double]                       = js.undefined,
+  max:                  js.UndefOr[Double]                             = js.undefined,
   /* The min value of progress, only works in determinate mode.*/
-  min:        js.UndefOr[Double]                       = js.undefined,
+  min:                  js.UndefOr[Double]                             = js.undefined,
   /* The mode of show your progress, indeterminate
   for when there is no value for progress.*/
-  mode:       js.UndefOr[DeterminateIndeterminate]     = js.undefined,
+  mode:                 js.UndefOr[DeterminateIndeterminate]           = js.undefined,
   /* The size of the progress.*/
-  size:       js.UndefOr[Double]                       = js.undefined,
+  size:                 js.UndefOr[Double]                             = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:      js.UndefOr[CssProperties]                = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The value of progress, only works in determinate mode.*/
-  value:      js.UndefOr[Double]                       = js.undefined){
+  value:                js.UndefOr[Double]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     val props = JSMacro[MuiCircularProgress](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.CircularProgress)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiDatePicker.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiDatePicker.scala
@@ -165,7 +165,81 @@ case class MuiDatePicker(
   underlineShow:           js.UndefOr[Boolean]                                    = js.undefined,
   /* Override the inline-styles of the TextField's underline element.
   (Passed on to TextField)*/
-  underlineStyle:          js.UndefOr[CssProperties]                              = js.undefined){
+  underlineStyle:          js.UndefOr[CssProperties]                              = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:          js.UndefOr[ReactEventI => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:    js.UndefOr[ReactEventI => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:        js.UndefOr[ReactEventI => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                 js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:        js.UndefOr[ReactCompositionEventI => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:      js.UndefOr[ReactCompositionEventI => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:     js.UndefOr[ReactCompositionEventI => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:           js.UndefOr[ReactEventI => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                  js.UndefOr[ReactClipboardEventI => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                   js.UndefOr[ReactClipboardEventI => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:           js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                  js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:               js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:             js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:              js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:             js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:              js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:             js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                  js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                 js.UndefOr[ReactKeyboardEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:              js.UndefOr[ReactKeyboardEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                 js.UndefOr[ReactKeyboardEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:             js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:            js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:            js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:             js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:               js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                 js.UndefOr[ReactClipboardEventI => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                js.UndefOr[ReactUIEventI => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                js.UndefOr[ReactUIEventI => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                js.UndefOr[ReactEventI => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:           js.UndefOr[ReactTouchEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:              js.UndefOr[ReactTouchEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:             js.UndefOr[ReactTouchEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:            js.UndefOr[ReactTouchEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:         js.UndefOr[ReactTouchEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                 js.UndefOr[ReactWheelEventI => Callback]               = js.undefined){
   def apply(children: ReactNode*) = {
     val props = JSMacro[MuiDatePicker](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.DatePicker)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiDialog.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiDialog.scala
@@ -8,51 +8,133 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiDialog(
-  key:                       js.UndefOr[String]              = js.undefined,
-  ref:                       js.UndefOr[String]              = js.undefined,
+  key:                       js.UndefOr[String]                             = js.undefined,
+  ref:                       js.UndefOr[String]                             = js.undefined,
   /* Action buttons to display below the Dialog content (`children`).
   This property accepts either a React element, or an array of React elements.*/
-  actions:                   js.UndefOr[ReactNode]           = js.undefined,
+  actions:                   js.UndefOr[ReactNode]                          = js.undefined,
   /* The `className` to add to the actions container's root element.*/
-  actionsContainerClassName: js.UndefOr[String]              = js.undefined,
+  actionsContainerClassName: js.UndefOr[String]                             = js.undefined,
   /* Overrides the inline-styles of the actions container's root element.*/
-  actionsContainerStyle:     js.UndefOr[CssProperties]       = js.undefined,
+  actionsContainerStyle:     js.UndefOr[CssProperties]                      = js.undefined,
   /* If set to true, the height of the `Dialog` will be auto detected. A max height
   will be enforced so that the content does not extend beyond the viewport.*/
-  autoDetectWindowHeight:    js.UndefOr[Boolean]             = js.undefined,
+  autoDetectWindowHeight:    js.UndefOr[Boolean]                            = js.undefined,
   /* If set to true, the body content of the `Dialog` will be scrollable.*/
-  autoScrollBodyContent:     js.UndefOr[Boolean]             = js.undefined,
+  autoScrollBodyContent:     js.UndefOr[Boolean]                            = js.undefined,
   /* The `className` to add to the content's root element under the title.*/
-  bodyClassName:             js.UndefOr[String]              = js.undefined,
+  bodyClassName:             js.UndefOr[String]                             = js.undefined,
   /* Overrides the inline-styles of the content's root element under the title.*/
-  bodyStyle:                 js.UndefOr[CssProperties]       = js.undefined,
+  bodyStyle:                 js.UndefOr[CssProperties]                      = js.undefined,
   /* The css class name of the root element.*/
-  className:                 js.UndefOr[String]              = js.undefined,
+  className:                 js.UndefOr[String]                             = js.undefined,
   /* The `className` to add to the content container.*/
-  contentClassName:          js.UndefOr[String]              = js.undefined,
+  contentClassName:          js.UndefOr[String]                             = js.undefined,
   /* Overrides the inline-styles of the content container.*/
-  contentStyle:              js.UndefOr[CssProperties]       = js.undefined,
+  contentStyle:              js.UndefOr[CssProperties]                      = js.undefined,
   /* Force the user to use one of the actions in the `Dialog`.
   Clicking outside the `Dialog` will not trigger the `onRequestClose`.*/
-  modal:                     js.UndefOr[Boolean]             = js.undefined,
+  modal:                     js.UndefOr[Boolean]                            = js.undefined,
   /* Fired when the `Dialog` is requested to be closed by a click outside the `Dialog` or on the buttons.*/
-  onRequestClose:            js.UndefOr[Boolean => Callback] = js.undefined,
+  onRequestClose:            js.UndefOr[Boolean => Callback]                = js.undefined,
   /* Controls whether the Dialog is opened or not.*/
   open:                      Boolean,
   /* The `className` to add to the `Overlay` component that is rendered behind the `Dialog`.*/
-  overlayClassName:          js.UndefOr[String]              = js.undefined,
+  overlayClassName:          js.UndefOr[String]                             = js.undefined,
   /* Overrides the inline-styles of the `Overlay` component that is rendered behind the `Dialog`.*/
-  overlayStyle:              js.UndefOr[CssProperties]       = js.undefined,
+  overlayStyle:              js.UndefOr[CssProperties]                      = js.undefined,
   /* Determines whether the `Dialog` should be repositioned when it's contents are updated.*/
-  repositionOnUpdate:        js.UndefOr[Boolean]             = js.undefined,
+  repositionOnUpdate:        js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                     js.UndefOr[CssProperties]       = js.undefined,
+  style:                     js.UndefOr[CssProperties]                      = js.undefined,
   /* The title to display on the `Dialog`. Could be number, string, element or an array containing these types.*/
-  title:                     js.UndefOr[ReactNode]           = js.undefined,
+  title:                     js.UndefOr[ReactNode]                          = js.undefined,
   /* The `className` to add to the title's root container element.*/
-  titleClassName:            js.UndefOr[String]              = js.undefined,
+  titleClassName:            js.UndefOr[String]                             = js.undefined,
   /* Overrides the inline-styles of the title's root container element.*/
-  titleStyle:                js.UndefOr[CssProperties]       = js.undefined){
+  titleStyle:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:            js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:      js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:          js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:                    js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:                  js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                   js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:          js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:        js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:       js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                    js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                     js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:             js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                    js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:                js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:                js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                    js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:                   js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                   js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:                 js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:                js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                   js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:               js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:               js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:                 js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                   js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                  js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                  js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                  js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:             js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:                js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:               js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:              js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                   js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children The contents of the `Dialog`.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiDivider.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiDivider.scala
@@ -8,14 +8,96 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiDivider(
-  key:       js.UndefOr[String]        = js.undefined,
-  ref:       js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* The css class name of the root element.*/
-  className: js.UndefOr[String]        = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* If true, the `Divider` will be indented `72px`.*/
-  inset:     js.UndefOr[Boolean]       = js.undefined,
+  inset:                js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:     js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     val props = JSMacro[MuiDivider](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.Divider)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiDrawer.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiDrawer.scala
@@ -8,43 +8,125 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiDrawer(
-  key:                js.UndefOr[String]                        = js.undefined,
-  ref:                js.UndefOr[MuiDrawerM => Unit]            = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiDrawerM => Unit]                 = js.undefined,
   /* The CSS class name of the root element.*/
-  className:          js.UndefOr[String]                        = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* The CSS class name of the container element.*/
-  containerClassName: js.UndefOr[String]                        = js.undefined,
+  containerClassName:   js.UndefOr[String]                             = js.undefined,
   /* Override the inline-styles of the container element.*/
-  containerStyle:     js.UndefOr[CssProperties]                 = js.undefined,
+  containerStyle:       js.UndefOr[CssProperties]                      = js.undefined,
   /* If true, swiping sideways when the `Drawer` is closed will not open it.*/
-  disableSwipeToOpen: js.UndefOr[Boolean]                       = js.undefined,
+  disableSwipeToOpen:   js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the `Drawer` will be docked. In this state, the overlay won't show and
   clicking on a menu item will not close the `Drawer`.*/
-  docked:             js.UndefOr[Boolean]                       = js.undefined,
+  docked:               js.UndefOr[Boolean]                            = js.undefined,
   /* Callback function fired when the `open` state of the `Drawer` is requested to be changed.
   'swipe' for open requests; 'clickaway' (on overlay clicks),
   'escape' (on escape key press), and 'swipe' for close requests.*/
-  onRequestChange:    js.UndefOr[(Boolean, String) => Callback] = js.undefined,
+  onRequestChange:      js.UndefOr[(Boolean, String) => Callback]      = js.undefined,
   /* If true, the `Drawer` is opened.  Providing a value will turn the `Drawer`
   into a controlled component.*/
-  open:               js.UndefOr[Boolean]                       = js.undefined,
+  open:                 js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the `Drawer` is positioned to open from the opposite side.*/
-  openSecondary:      js.UndefOr[Boolean]                       = js.undefined,
+  openSecondary:        js.UndefOr[Boolean]                            = js.undefined,
   /* The CSS class name to add to the `Overlay` component that is rendered behind the `Drawer`.*/
-  overlayClassName:   js.UndefOr[String]                        = js.undefined,
+  overlayClassName:     js.UndefOr[String]                             = js.undefined,
   /* Override the inline-styles of the `Overlay` component that is rendered behind the `Drawer`.*/
-  overlayStyle:       js.UndefOr[CssProperties]                 = js.undefined,
+  overlayStyle:         js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:              js.UndefOr[CssProperties]                 = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The width of the left most (or right most) area in pixels where the `Drawer` can be
   swiped open from. Setting this to `null` spans that area to the entire page
   (**CAUTION!** Setting this property to `null` might cause issues with sliders and
   swipeable `Tabs`: use at your own risk).*/
-  swipeAreaWidth:     js.UndefOr[Double]                        = js.undefined,
+  swipeAreaWidth:       js.UndefOr[Double]                             = js.undefined,
   /* The width of the `Drawer` in pixels. Defaults to using the values from theme.*/
-  width:              js.UndefOr[Double]                        = js.undefined,
+  width:                js.UndefOr[Double]                             = js.undefined,
   /* The zDepth of the `Drawer`.*/
-  zDepth:             js.UndefOr[ZDepth]                        = js.undefined){
+  zDepth:               js.UndefOr[ZDepth]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children The contents of the `Drawer`
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiDropdownMenu.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiDropdownMenu.scala
@@ -8,38 +8,118 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiDropDownMenu[T](
-  key:             js.UndefOr[String]                            = js.undefined,
-  ref:             js.UndefOr[MuiDropDownMenuM => Unit]          = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiDropDownMenuM => Unit]           = js.undefined,
   /* If true, the popover will apply transitions when
   it gets added to the DOM.*/
-  animated:        js.UndefOr[Boolean]                           = js.undefined,
+  animated:             js.UndefOr[Boolean]                            = js.undefined,
   /* The width will automatically be set according to the items inside the menu.
   To control this width in css instead, set this prop to `false`.*/
-  autoWidth:       js.UndefOr[Boolean]                           = js.undefined,
+  autoWidth:            js.UndefOr[Boolean]                            = js.undefined,
   /* The css class name of the root element.*/
-  className:       js.UndefOr[String]                            = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* Disables the menu.*/
-  disabled:        js.UndefOr[Boolean]                           = js.undefined,
+  disabled:             js.UndefOr[Boolean]                            = js.undefined,
   /* Overrides the styles of icon element.*/
-  iconStyle:       js.UndefOr[CssProperties]                     = js.undefined,
+  iconStyle:            js.UndefOr[CssProperties]                      = js.undefined,
   /* Overrides the styles of label when the `DropDownMenu` is inactive.*/
-  labelStyle:      js.UndefOr[CssProperties]                     = js.undefined,
+  labelStyle:           js.UndefOr[CssProperties]                      = js.undefined,
   /* The style object to use to override underlying list style.*/
-  listStyle:       js.UndefOr[CssProperties]                     = js.undefined,
+  listStyle:            js.UndefOr[CssProperties]                      = js.undefined,
   /* The maximum height of the `Menu` when it is displayed.*/
-  maxHeight:       js.UndefOr[Int]                               = js.undefined,
+  maxHeight:            js.UndefOr[Int]                                = js.undefined,
   /* Overrides the styles of `Menu` when the `DropDownMenu` is displayed.*/
-  menuStyle:       js.UndefOr[CssProperties]                     = js.undefined,
+  menuStyle:            js.UndefOr[CssProperties]                      = js.undefined,
   /* Callback function fired when a menu item is clicked, other than the one currently selected.*/
-  onChange:        js.UndefOr[(ReactEventI, Int, T) => Callback] = js.undefined,
+  onChange:             js.UndefOr[(ReactEventI, Int, T) => Callback]  = js.undefined,
   /* Set to true to have the `DropDownMenu` automatically open on mount.*/
-  openImmediately: js.UndefOr[Boolean]                           = js.undefined,
+  openImmediately:      js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:           js.UndefOr[CssProperties]                     = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* Overrides the inline-styles of the underline.*/
-  underlineStyle:  js.UndefOr[CssProperties]                     = js.undefined,
+  underlineStyle:       js.UndefOr[CssProperties]                      = js.undefined,
   /* The value that is currently selected.*/
-  value:           js.UndefOr[T]                                 = js.undefined){
+  value:                js.UndefOr[T]                                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children The `MenuItem`s to populate the `Menu` with. If the `MenuItems` have the
 prop `label` that value will be used to render the representation of that

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiFlatButton.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiFlatButton.scala
@@ -8,84 +8,144 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiFlatButton(
-  key:                  js.UndefOr[String]                          = js.undefined,
-  ref:                  js.UndefOr[String]                          = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* Color of button when mouse is not hovering over it.*/
-  backgroundColor:      js.UndefOr[MuiColor]                        = js.undefined,
+  backgroundColor:      js.UndefOr[MuiColor]                           = js.undefined,
   /* Disables the button if set to true.*/
-  disabled:             js.UndefOr[Boolean]                         = js.undefined,
+  disabled:             js.UndefOr[Boolean]                            = js.undefined,
   /* Color of button when mouse hovers over.*/
-  hoverColor:           js.UndefOr[MuiColor]                        = js.undefined,
+  hoverColor:           js.UndefOr[MuiColor]                           = js.undefined,
   /* The URL to link to when the button is clicked.*/
-  href:                 js.UndefOr[String]                          = js.undefined,
+  href:                 js.UndefOr[String]                             = js.undefined,
   /* Use this property to display an icon.*/
-  icon:                 js.UndefOr[ReactNode]                       = js.undefined,
+  icon:                 js.UndefOr[ReactNode]                          = js.undefined,
   /* Label for the button.*/
-  label:                js.UndefOr[String]                          = js.undefined,
+  label:                js.UndefOr[String]                             = js.undefined,
   /* Place label before or after the passed children.*/
-  labelPosition:        js.UndefOr[BeforeAfter]                     = js.undefined,
+  labelPosition:        js.UndefOr[BeforeAfter]                        = js.undefined,
   /* Override the inline-styles of the button's label element.*/
-  labelStyle:           js.UndefOr[CssProperties]                   = js.undefined,
+  labelStyle:           js.UndefOr[CssProperties]                      = js.undefined,
   /* Callback function fired when the element is focused or blurred by the keyboard.*/
-  onKeyboardFocus:      js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
-  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onKeyboardFocus:      js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* If true, colors button according to
   primaryTextColor from the Theme.*/
-  primary:              js.UndefOr[Boolean]                         = js.undefined,
+  primary:              js.UndefOr[Boolean]                            = js.undefined,
   /* Color for the ripple after button is clicked.*/
-  rippleColor:          js.UndefOr[MuiColor]                        = js.undefined,
+  rippleColor:          js.UndefOr[MuiColor]                           = js.undefined,
   /* If true, colors button according to secondaryTextColor from the theme.
   The primary prop has precendent if set to true.*/
-  secondary:            js.UndefOr[Boolean]                         = js.undefined,
+  secondary:            js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                js.UndefOr[CssProperties]                   = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  centerRipple:         js.UndefOr[Boolean]                         = js.undefined,
+  centerRipple:         js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  containerElement:     js.UndefOr[String | ReactElement]           = js.undefined,
+  containerElement:     js.UndefOr[String | ReactElement]              = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableFocusRipple:   js.UndefOr[Boolean]                         = js.undefined,
+  disableFocusRipple:   js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableKeyboardFocus: js.UndefOr[Boolean]                         = js.undefined,
+  disableKeyboardFocus: js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableTouchRipple:   js.UndefOr[Boolean]                         = js.undefined,
+  disableTouchRipple:   js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleColor:     js.UndefOr[MuiColor]                        = js.undefined,
+  focusRippleColor:     js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleOpacity:   js.UndefOr[Double]                          = js.undefined,
+  focusRippleOpacity:   js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  keyboardFocused:      js.UndefOr[Boolean]                         = js.undefined,
+  keyboardFocused:      js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
   @deprecated("LinkButton is no longer required when the `href` property is provided.\n      It will be removed with v0.16.0.")
-  linkButton:           js.UndefOr[Boolean]                         = js.undefined,
+  linkButton:           js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onBlur:               js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onClick:              js.UndefOr[ReactEventH => Callback]         = js.undefined,
+  onClick:              js.UndefOr[ReactEventH => Callback]            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onFocus:              js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onTouchTap:           js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchTap:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  tabIndex:             js.UndefOr[Double]                          = js.undefined,
+  tabIndex:             js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleColor:     js.UndefOr[MuiColor]                        = js.undefined,
+  touchRippleColor:     js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleOpacity:   js.UndefOr[Double]                          = js.undefined,
+  touchRippleOpacity:   js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  `type`:               js.UndefOr[String]                          = js.undefined){
+  `type`:               js.UndefOr[String]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children This is what will be displayed inside the button.
 If a label is specified, the text within the label prop will

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiFloatingActionButton.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiFloatingActionButton.scala
@@ -8,83 +8,143 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiFloatingActionButton(
-  key:                  js.UndefOr[String]                          = js.undefined,
-  ref:                  js.UndefOr[String]                          = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* This value will override the default background color for the button.
   However it will not override the default disabled background color.
   This has to be set separately using the disabledColor attribute.*/
-  backgroundColor:      js.UndefOr[MuiColor]                        = js.undefined,
+  backgroundColor:      js.UndefOr[MuiColor]                           = js.undefined,
   /* The css class name of the root element.*/
-  className:            js.UndefOr[String]                          = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* Disables the button if set to true.*/
-  disabled:             js.UndefOr[Boolean]                         = js.undefined,
+  disabled:             js.UndefOr[Boolean]                            = js.undefined,
   /* This value will override the default background color for the button when it is disabled.*/
-  disabledColor:        js.UndefOr[MuiColor]                        = js.undefined,
+  disabledColor:        js.UndefOr[MuiColor]                           = js.undefined,
   /* The URL to link to when the button is clicked.*/
-  href:                 js.UndefOr[String]                          = js.undefined,
+  href:                 js.UndefOr[String]                             = js.undefined,
   /* The icon within the FloatingActionButton is a FontIcon component.
   This property is the classname of the icon to be displayed inside the button.
   An alternative to adding an iconClassName would be to manually insert a
   FontIcon component or custom SvgIcon component or as a child of FloatingActionButton.*/
-  iconClassName:        js.UndefOr[String]                          = js.undefined,
+  iconClassName:        js.UndefOr[String]                             = js.undefined,
   /* This is the equivalent to iconClassName except that it is used for
   overriding the inline-styles of the FontIcon component.*/
-  iconStyle:            js.UndefOr[CssProperties]                   = js.undefined,
+  iconStyle:            js.UndefOr[CssProperties]                      = js.undefined,
   /* If true, the button will be a small floating action button.*/
-  mini:                 js.UndefOr[Boolean]                         = js.undefined,
-  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
-  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  mini:                 js.UndefOr[Boolean]                            = js.undefined,
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* If true, the button will use the secondary button colors.*/
-  secondary:            js.UndefOr[Boolean]                         = js.undefined,
+  secondary:            js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                js.UndefOr[CssProperties]                   = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The zDepth of the underlying `Paper` component.*/
-  zDepth:               js.UndefOr[ZDepth]                          = js.undefined,
+  zDepth:               js.UndefOr[ZDepth]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  centerRipple:         js.UndefOr[Boolean]                         = js.undefined,
+  centerRipple:         js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  containerElement:     js.UndefOr[String | ReactElement]           = js.undefined,
+  containerElement:     js.UndefOr[String | ReactElement]              = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableFocusRipple:   js.UndefOr[Boolean]                         = js.undefined,
+  disableFocusRipple:   js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableKeyboardFocus: js.UndefOr[Boolean]                         = js.undefined,
+  disableKeyboardFocus: js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableTouchRipple:   js.UndefOr[Boolean]                         = js.undefined,
+  disableTouchRipple:   js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleColor:     js.UndefOr[MuiColor]                        = js.undefined,
+  focusRippleColor:     js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleOpacity:   js.UndefOr[Double]                          = js.undefined,
+  focusRippleOpacity:   js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  keyboardFocused:      js.UndefOr[Boolean]                         = js.undefined,
+  keyboardFocused:      js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
   @deprecated("LinkButton is no longer required when the `href` property is provided.\n      It will be removed with v0.16.0.")
-  linkButton:           js.UndefOr[Boolean]                         = js.undefined,
+  linkButton:           js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onBlur:               js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onClick:              js.UndefOr[ReactEventH => Callback]         = js.undefined,
+  onClick:              js.UndefOr[ReactEventH => Callback]            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onFocus:              js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyboardFocus:      js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyboardFocus:      js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onTouchTap:           js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchTap:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  tabIndex:             js.UndefOr[Double]                          = js.undefined,
+  tabIndex:             js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleColor:     js.UndefOr[MuiColor]                        = js.undefined,
+  touchRippleColor:     js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleOpacity:   js.UndefOr[Double]                          = js.undefined,
+  touchRippleOpacity:   js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  `type`:               js.UndefOr[String]                          = js.undefined){
+  `type`:               js.UndefOr[String]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children This is what displayed inside the floating action button; for example, a SVG Icon.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiFontIcon.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiFontIcon.scala
@@ -8,17 +8,95 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiFontIcon(
-  key:          js.UndefOr[String]                       = js.undefined,
-  ref:          js.UndefOr[String]                       = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* This is the font color of the font icon. If not specified,
   this component will default to muiTheme.palette.textColor.*/
-  color:        js.UndefOr[MuiColor]                     = js.undefined,
+  color:                js.UndefOr[MuiColor]                           = js.undefined,
   /* This is the icon color when the mouse hovers over the icon.*/
-  hoverColor:   js.UndefOr[MuiColor]                     = js.undefined,
-  onMouseEnter: js.UndefOr[ReactMouseEventH => Callback] = js.undefined,
-  onMouseLeave: js.UndefOr[ReactMouseEventH => Callback] = js.undefined,
+  hoverColor:           js.UndefOr[MuiColor]                           = js.undefined,
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:        js.UndefOr[CssProperties]                = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     val props = JSMacro[MuiFontIcon](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.FontIcon)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiGridList.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiGridList.scala
@@ -8,16 +8,98 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiGridList(
-  key:        js.UndefOr[String]        = js.undefined,
-  ref:        js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* Number of px for one cell height.*/
-  cellHeight: js.UndefOr[Int]           = js.undefined,
+  cellHeight:           js.UndefOr[Int]                                = js.undefined,
   /* Number of columns.*/
-  cols:       js.UndefOr[Int]           = js.undefined,
+  cols:                 js.UndefOr[Int]                                = js.undefined,
   /* Number of px for the padding/spacing between items.*/
-  padding:    js.UndefOr[Int]           = js.undefined,
+  padding:              js.UndefOr[Int]                                = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:      js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Grid Tiles that will be in Grid List.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiGridTile.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiGridTile.scala
@@ -8,34 +8,116 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiGridTile(
-  key:              js.UndefOr[String]                = js.undefined,
-  ref:              js.UndefOr[MuiGridTileM => Unit]  = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiGridTileM => Unit]               = js.undefined,
   /* An IconButton element to be used as secondary action target
   (primary action target is the tile itself).*/
-  actionIcon:       js.UndefOr[ReactElement]          = js.undefined,
+  actionIcon:           js.UndefOr[ReactElement]                       = js.undefined,
   /* Position of secondary action IconButton.*/
-  actionPosition:   js.UndefOr[LeftRight]             = js.undefined,
+  actionPosition:       js.UndefOr[LeftRight]                          = js.undefined,
   /* Width of the tile in number of grid cells.*/
-  cols:             js.UndefOr[Int]                   = js.undefined,
+  cols:                 js.UndefOr[Int]                                = js.undefined,
   /* Either a string used as tag name for the tile root element, or a ReactElement.
   This is useful when you have, for example, a custom implementation of
   a navigation link (that knows about your routes) and you want to use it as the primary tile action.
   In case you pass a ReactElement, please ensure that it passes all props,
   accepts styles overrides and render it's children.*/
-  containerElement: js.UndefOr[String | ReactElement] = js.undefined,
+  containerElement:     js.UndefOr[String | ReactElement]              = js.undefined,
   /* Height of the tile in number of grid cells.*/
-  rows:             js.UndefOr[Int]                   = js.undefined,
+  rows:                 js.UndefOr[Int]                                = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:            js.UndefOr[CssProperties]         = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* String or element serving as subtitle (support text).*/
-  subtitle:         js.UndefOr[ReactNode]             = js.undefined,
+  subtitle:             js.UndefOr[ReactNode]                          = js.undefined,
   /* Title to be displayed on tile.*/
-  title:            js.UndefOr[ReactNode]             = js.undefined,
+  title:                js.UndefOr[ReactNode]                          = js.undefined,
   /* Style used for title bar background.
   Useful for setting custom gradients for example*/
-  titleBackground:  js.UndefOr[String]                = js.undefined,
+  titleBackground:      js.UndefOr[String]                             = js.undefined,
   /* Position of the title bar (container of title, subtitle and action icon).*/
-  titlePosition:    js.UndefOr[TopBottom]             = js.undefined){
+  titlePosition:        js.UndefOr[TopBottom]                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Theoretically you can pass any node as children, but the main use case is to pass an img,
 in whichcase GridTile takes care of making the image "cover" available space

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiIconButton.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiIconButton.scala
@@ -8,81 +8,141 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiIconButton(
-  key:                  js.UndefOr[String]                          = js.undefined,
-  ref:                  js.UndefOr[MuiIconButtonM => Unit]          = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiIconButtonM => Unit]             = js.undefined,
   /* The CSS class name of the root element.*/
-  className:            js.UndefOr[String]                          = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* If true, the element's ripple effect will be disabled.*/
-  disableTouchRipple:   js.UndefOr[Boolean]                         = js.undefined,
+  disableTouchRipple:   js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the element will be disabled.*/
-  disabled:             js.UndefOr[Boolean]                         = js.undefined,
+  disabled:             js.UndefOr[Boolean]                            = js.undefined,
   /* The URL to link to when the button is clicked.*/
-  href:                 js.UndefOr[String]                          = js.undefined,
+  href:                 js.UndefOr[String]                             = js.undefined,
   /* The CSS class name of the icon. Used for setting the icon with a stylesheet.*/
-  iconClassName:        js.UndefOr[String]                          = js.undefined,
+  iconClassName:        js.UndefOr[String]                             = js.undefined,
   /* Override the inline-styles of the icon element.*/
-  iconStyle:            js.UndefOr[CssProperties]                   = js.undefined,
-  onBlur:               js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
-  onFocus:              js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  iconStyle:            js.UndefOr[CssProperties]                      = js.undefined,
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* Callback function fired when the element is focused or blurred by the keyboard.*/
-  onKeyboardFocus:      js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
-  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onMouseOut:           js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onKeyboardFocus:      js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseOut:           js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                js.UndefOr[CssProperties]                   = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The text to supply to the element's tooltip.*/
-  tooltip:              js.UndefOr[ReactNode]                       = js.undefined,
+  tooltip:              js.UndefOr[ReactNode]                          = js.undefined,
   /* The vertical and horizontal positions, respectively, of the element's tooltip.
   Possible values are: "bottom-center", "top-center", "bottom-right", "top-right",
   "bottom-left", and "top-left".*/
-  tooltipPosition:      js.UndefOr[CornersAndCenter]                = js.undefined,
+  tooltipPosition:      js.UndefOr[CornersAndCenter]                   = js.undefined,
   /* Override the inline-styles of the tooltip element.*/
-  tooltipStyles:        js.UndefOr[CssProperties]                   = js.undefined,
+  tooltipStyles:        js.UndefOr[CssProperties]                      = js.undefined,
   /* If true, increase the tooltip element's size.  Useful for increasing tooltip
   readability on mobile devices.*/
-  touch:                js.UndefOr[Boolean]                         = js.undefined,
+  touch:                js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  centerRipple:         js.UndefOr[Boolean]                         = js.undefined,
+  centerRipple:         js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  containerElement:     js.UndefOr[String | ReactElement]           = js.undefined,
+  containerElement:     js.UndefOr[String | ReactElement]              = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableFocusRipple:   js.UndefOr[Boolean]                         = js.undefined,
+  disableFocusRipple:   js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableKeyboardFocus: js.UndefOr[Boolean]                         = js.undefined,
+  disableKeyboardFocus: js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleColor:     js.UndefOr[MuiColor]                        = js.undefined,
+  focusRippleColor:     js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleOpacity:   js.UndefOr[Double]                          = js.undefined,
+  focusRippleOpacity:   js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  keyboardFocused:      js.UndefOr[Boolean]                         = js.undefined,
+  keyboardFocused:      js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
   @deprecated("LinkButton is no longer required when the `href` property is provided.\n      It will be removed with v0.16.0.")
-  linkButton:           js.UndefOr[Boolean]                         = js.undefined,
+  linkButton:           js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onClick:              js.UndefOr[ReactEventH => Callback]         = js.undefined,
+  onClick:              js.UndefOr[ReactEventH => Callback]            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onTouchTap:           js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchTap:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  tabIndex:             js.UndefOr[Double]                          = js.undefined,
+  tabIndex:             js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleColor:     js.UndefOr[MuiColor]                        = js.undefined,
+  touchRippleColor:     js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleOpacity:   js.UndefOr[Double]                          = js.undefined,
+  touchRippleOpacity:   js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  `type`:               js.UndefOr[String]                          = js.undefined){
+  `type`:               js.UndefOr[String]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be used to pass a `FontIcon` element as the icon for the button.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiIconMenu.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiIconMenu.scala
@@ -122,7 +122,77 @@ case class MuiIconMenu[T](
   /* Menu no longer supports `zDepth`. Instead, wrap it in `Paper`
   or another component that provides zDepth.
   (Passed on to Menu)*/
-  zDepth:                   js.UndefOr[ZDepth]                                       = js.undefined){
+  zDepth:                   js.UndefOr[ZDepth]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:           js.UndefOr[ReactEventH => Callback]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:     js.UndefOr[ReactEventH => Callback]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:         js.UndefOr[ReactEventH => Callback]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:                   js.UndefOr[ReactFocusEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                  js.UndefOr[ReactMouseEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:         js.UndefOr[ReactCompositionEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:       js.UndefOr[ReactCompositionEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:      js.UndefOr[ReactCompositionEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:            js.UndefOr[ReactEventH => Callback]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                   js.UndefOr[ReactClipboardEventH => Callback]             = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                    js.UndefOr[ReactClipboardEventH => Callback]             = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:            js.UndefOr[ReactMouseEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                   js.UndefOr[ReactDragEventH => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:                js.UndefOr[ReactDragEventH => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:              js.UndefOr[ReactDragEventH => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:               js.UndefOr[ReactDragEventH => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:              js.UndefOr[ReactDragEventH => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:               js.UndefOr[ReactDragEventH => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:              js.UndefOr[ReactDragEventH => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                   js.UndefOr[ReactDragEventH => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:                  js.UndefOr[ReactFocusEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                  js.UndefOr[ReactKeyboardEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:               js.UndefOr[ReactKeyboardEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                  js.UndefOr[ReactKeyboardEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:              js.UndefOr[ReactMouseEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                  js.UndefOr[ReactClipboardEventH => Callback]             = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                 js.UndefOr[ReactUIEventH => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                 js.UndefOr[ReactUIEventH => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                 js.UndefOr[ReactEventH => Callback]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:            js.UndefOr[ReactTouchEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:               js.UndefOr[ReactTouchEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:              js.UndefOr[ReactTouchEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:             js.UndefOr[ReactTouchEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:          js.UndefOr[ReactTouchEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                  js.UndefOr[ReactWheelEventH => Callback]                 = js.undefined){
   /**
    * @param children Should be used to pass `MenuItem` components.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiLinearProgress.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiLinearProgress.scala
@@ -8,22 +8,104 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiLinearProgress(
-  key:   js.UndefOr[String]                     = js.undefined,
-  ref:   js.UndefOr[MuiLinearProgressM => Unit] = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiLinearProgressM => Unit]         = js.undefined,
   /* The mode of show your progress, indeterminate for
   when there is no value for progress.*/
-  color: js.UndefOr[MuiColor]                   = js.undefined,
+  color:                js.UndefOr[MuiColor]                           = js.undefined,
   /* The max value of progress, only works in determinate mode.*/
-  max:   js.UndefOr[Double]                     = js.undefined,
+  max:                  js.UndefOr[Double]                             = js.undefined,
   /* The min value of progress, only works in determinate mode.*/
-  min:   js.UndefOr[Double]                     = js.undefined,
+  min:                  js.UndefOr[Double]                             = js.undefined,
   /* The mode of show your progress, indeterminate for when
   there is no value for progress.*/
-  mode:  js.UndefOr[DeterminateIndeterminate]   = js.undefined,
+  mode:                 js.UndefOr[DeterminateIndeterminate]           = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style: js.UndefOr[CssProperties]              = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The value of progress, only works in determinate mode.*/
-  value: js.UndefOr[Double]                     = js.undefined){
+  value:                js.UndefOr[Double]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     val props = JSMacro[MuiLinearProgress](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.LinearProgress)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiList.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiList.scala
@@ -8,22 +8,104 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiList(
-  key:            js.UndefOr[String]        = js.undefined,
-  ref:            js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* If true, the subheader will be indented by 72px.*/
   @deprecated("Refer to the `subheader` property. It will be removed with v0.16.0.")
-  insetSubheader: js.UndefOr[Boolean]       = js.undefined,
+  insetSubheader:       js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:          js.UndefOr[CssProperties] = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The subheader string that will be displayed at the top of the list.*/
   @deprecated("Instead, nest the `Subheader` component directly inside the `List`. It will be removed with v0.16.0.")
-  subheader:      js.UndefOr[ReactNode]     = js.undefined,
+  subheader:            js.UndefOr[ReactNode]                          = js.undefined,
   /* Override the inline-styles of the subheader element.*/
   @deprecated("Refer to the `subheader` property. It will be removed with v0.16.0.")
-  subheaderStyle: js.UndefOr[CssProperties] = js.undefined,
+  subheaderStyle:       js.UndefOr[CssProperties]                      = js.undefined,
   /* ** Breaking change ** List no longer supports `zDepth`. Instead, wrap it in `Paper`
   or another component that provides zDepth.*/
-  zDepth:         js.UndefOr[ZDepth]        = js.undefined){
+  zDepth:               js.UndefOr[ZDepth]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children These are usually `ListItem`s that are passed to
 be part of the list.

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiListItem.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiListItem.scala
@@ -8,117 +8,177 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiListItem(
-  key:                         js.UndefOr[String]                          = js.undefined,
-  ref:                         js.UndefOr[MuiListItemM => Unit]            = js.undefined,
+  key:                         js.UndefOr[String]                             = js.undefined,
+  ref:                         js.UndefOr[MuiListItemM => Unit]               = js.undefined,
   /* If true, generate a nested-list-indicator icon when nested list
   items are detected. Note that an indicator will not be created
   if a `rightIcon` or `rightIconButton` has been provided to
   the element.*/
-  autoGenerateNestedIndicator: js.UndefOr[Boolean]                         = js.undefined,
+  autoGenerateNestedIndicator: js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the element will not be able to be focused by the keyboard.*/
-  disableKeyboardFocus:        js.UndefOr[Boolean]                         = js.undefined,
+  disableKeyboardFocus:        js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the element will not be clickable
   and will not display hover effects.
   This is automatically disabled if either `leftCheckbox`
   or `rightToggle` is set.*/
-  disabled:                    js.UndefOr[Boolean]                         = js.undefined,
+  disabled:                    js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the nested `ListItem`s are initially displayed.*/
-  initiallyOpen:               js.UndefOr[Boolean]                         = js.undefined,
+  initiallyOpen:               js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the inner div element.*/
-  innerDivStyle:               js.UndefOr[CssProperties]                   = js.undefined,
+  innerDivStyle:               js.UndefOr[CssProperties]                      = js.undefined,
   /* If true, the children will be indented by 72px.
   This is useful if there is no left avatar or left icon.*/
-  insetChildren:               js.UndefOr[Boolean]                         = js.undefined,
+  insetChildren:               js.UndefOr[Boolean]                            = js.undefined,
   /* This is the `Avatar` element to be displayed on the left side.*/
-  leftAvatar:                  js.UndefOr[ReactElement]                    = js.undefined,
+  leftAvatar:                  js.UndefOr[ReactElement]                       = js.undefined,
   /* This is the `Checkbox` element to be displayed on the left side.*/
-  leftCheckbox:                js.UndefOr[ReactElement]                    = js.undefined,
+  leftCheckbox:                js.UndefOr[ReactElement]                       = js.undefined,
   /* This is the `SvgIcon` or `FontIcon` to be displayed on the left side.*/
-  leftIcon:                    js.UndefOr[ReactElement]                    = js.undefined,
+  leftIcon:                    js.UndefOr[ReactElement]                       = js.undefined,
   /* An array of `ListItem`s to nest underneath the current `ListItem`.*/
-  nestedItems:                 js.UndefOr[js.Array[ReactElement]]          = js.undefined,
+  nestedItems:                 js.UndefOr[js.Array[ReactElement]]             = js.undefined,
   /* Controls how deep a `ListItem` appears.
   This property is automatically managed, so modify at your own risk.*/
-  nestedLevel:                 js.UndefOr[Int]                             = js.undefined,
+  nestedLevel:                 js.UndefOr[Int]                                = js.undefined,
   /* Override the inline-styles of the nested items' `NestedList`.*/
-  nestedListStyle:             js.UndefOr[CssProperties]                   = js.undefined,
+  nestedListStyle:             js.UndefOr[CssProperties]                      = js.undefined,
   /* Callback function fired when the `ListItem` is focused or blurred by the keyboard.*/
-  onKeyboardFocus:             js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
-  onMouseEnter:                js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onMouseLeave:                js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onKeyboardFocus:             js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  onMouseEnter:                js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseLeave:                js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* Callbak function fired when the `ListItem` toggles its nested list.*/
-  onNestedListToggle:          js.UndefOr[js.Any => Callback]              = js.undefined,
-  onTouchStart:                js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
-  onTouchTap:                  js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onNestedListToggle:          js.UndefOr[js.Any => Callback]                 = js.undefined,
+  onTouchStart:                js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  onTouchTap:                  js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* This is the block element that contains the primary text.
   If a string is passed in, a div tag will be rendered.*/
-  primaryText:                 js.UndefOr[ReactNode]                       = js.undefined,
+  primaryText:                 js.UndefOr[ReactNode]                          = js.undefined,
   /* If true, clicking or tapping the primary text of the `ListItem`
   toggles the nested list.*/
-  primaryTogglesNestedList:    js.UndefOr[Boolean]                         = js.undefined,
+  primaryTogglesNestedList:    js.UndefOr[Boolean]                            = js.undefined,
   /* This is the `Avatar` element to be displayed on the right side.*/
-  rightAvatar:                 js.UndefOr[ReactElement]                    = js.undefined,
+  rightAvatar:                 js.UndefOr[ReactElement]                       = js.undefined,
   /* This is the `SvgIcon` or `FontIcon` to be displayed on the right side.*/
-  rightIcon:                   js.UndefOr[ReactElement]                    = js.undefined,
+  rightIcon:                   js.UndefOr[ReactElement]                       = js.undefined,
   /* This is the `IconButton` to be displayed on the right side.
   Hovering over this button will remove the `ListItem` hover.
   Also, clicking on this button will not trigger a
   ripple on the `ListItem`; the event will be stopped and prevented
   from bubbling up to cause a `ListItem` click.*/
-  rightIconButton:             js.UndefOr[ReactElement]                    = js.undefined,
+  rightIconButton:             js.UndefOr[ReactElement]                       = js.undefined,
   /* This is the `Toggle` element to display on the right side.*/
-  rightToggle:                 js.UndefOr[ReactElement]                    = js.undefined,
+  rightToggle:                 js.UndefOr[ReactElement]                       = js.undefined,
   /* This is the block element that contains the secondary text.
   If a string is passed in, a div tag will be rendered.*/
-  secondaryText:               js.UndefOr[ReactNode]                       = js.undefined,
+  secondaryText:               js.UndefOr[ReactNode]                          = js.undefined,
   /* Can be 1 or 2. This is the number of secondary
   text lines before ellipsis will show.*/
-  secondaryTextLines:          js.UndefOr[_1_2]                            = js.undefined,
+  secondaryTextLines:          js.UndefOr[_1_2]                               = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                       js.UndefOr[CssProperties]                   = js.undefined,
+  style:                       js.UndefOr[CssProperties]                      = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  centerRipple:                js.UndefOr[Boolean]                         = js.undefined,
+  centerRipple:                js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  containerElement:            js.UndefOr[String | ReactElement]           = js.undefined,
+  containerElement:            js.UndefOr[String | ReactElement]              = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableFocusRipple:          js.UndefOr[Boolean]                         = js.undefined,
+  disableFocusRipple:          js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableTouchRipple:          js.UndefOr[Boolean]                         = js.undefined,
+  disableTouchRipple:          js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleColor:            js.UndefOr[MuiColor]                        = js.undefined,
+  focusRippleColor:            js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleOpacity:          js.UndefOr[Double]                          = js.undefined,
+  focusRippleOpacity:          js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  href:                        js.UndefOr[String]                          = js.undefined,
+  href:                        js.UndefOr[String]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  keyboardFocused:             js.UndefOr[Boolean]                         = js.undefined,
+  keyboardFocused:             js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
   @deprecated("LinkButton is no longer required when the `href` property is provided.\n      It will be removed with v0.16.0.")
-  linkButton:                  js.UndefOr[Boolean]                         = js.undefined,
+  linkButton:                  js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onBlur:                      js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  onBlur:                      js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onClick:                     js.UndefOr[ReactEventH => Callback]         = js.undefined,
+  onClick:                     js.UndefOr[ReactEventH => Callback]            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onFocus:                     js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  onFocus:                     js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyDown:                   js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyDown:                   js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyUp:                     js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyUp:                     js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onMouseDown:                 js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseDown:                 js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onMouseUp:                   js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseUp:                   js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onTouchEnd:                  js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchEnd:                  js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  tabIndex:                    js.UndefOr[Double]                          = js.undefined,
+  tabIndex:                    js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleColor:            js.UndefOr[MuiColor]                        = js.undefined,
+  touchRippleColor:            js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleOpacity:          js.UndefOr[Double]                          = js.undefined,
+  touchRippleOpacity:          js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  `type`:                      js.UndefOr[String]                          = js.undefined){
+  `type`:                      js.UndefOr[String]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:              js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:            js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:                    js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:            js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:          js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:         js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:               js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                      js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                       js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:               js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                      js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:                   js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:                  js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:                  js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                      js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                     js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:                  js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:                 js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                     js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                    js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                    js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                    js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:               js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:                 js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:             js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                     js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Children passed into the `ListItem`.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiMenu.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiMenu.scala
@@ -79,7 +79,85 @@ case class MuiMenu[T](
   /* Override the inline-styles of the subheader element.
   (Passed on to List)*/
   @deprecated("Refer to the `subheader` property. It will be removed with v0.16.0.")
-  subheaderStyle:           js.UndefOr[CssProperties]                                                      = js.undefined){
+  subheaderStyle:           js.UndefOr[CssProperties]                                                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:           js.UndefOr[ReactEventH => Callback]                                            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:     js.UndefOr[ReactEventH => Callback]                                            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:         js.UndefOr[ReactEventH => Callback]                                            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:                   js.UndefOr[ReactFocusEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                  js.UndefOr[ReactMouseEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:         js.UndefOr[ReactCompositionEventH => Callback]                                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:       js.UndefOr[ReactCompositionEventH => Callback]                                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:      js.UndefOr[ReactCompositionEventH => Callback]                                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:            js.UndefOr[ReactEventH => Callback]                                            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                   js.UndefOr[ReactClipboardEventH => Callback]                                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                    js.UndefOr[ReactClipboardEventH => Callback]                                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:            js.UndefOr[ReactMouseEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                   js.UndefOr[ReactDragEventH => Callback]                                        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:                js.UndefOr[ReactDragEventH => Callback]                                        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:              js.UndefOr[ReactDragEventH => Callback]                                        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:               js.UndefOr[ReactDragEventH => Callback]                                        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:              js.UndefOr[ReactDragEventH => Callback]                                        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:               js.UndefOr[ReactDragEventH => Callback]                                        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:              js.UndefOr[ReactDragEventH => Callback]                                        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                   js.UndefOr[ReactDragEventH => Callback]                                        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:                  js.UndefOr[ReactFocusEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                  js.UndefOr[ReactKeyboardEventH => Callback]                                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:               js.UndefOr[ReactKeyboardEventH => Callback]                                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                  js.UndefOr[ReactKeyboardEventH => Callback]                                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:              js.UndefOr[ReactMouseEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:             js.UndefOr[ReactMouseEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:             js.UndefOr[ReactMouseEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:              js.UndefOr[ReactMouseEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:                js.UndefOr[ReactMouseEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                  js.UndefOr[ReactClipboardEventH => Callback]                                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                 js.UndefOr[ReactUIEventH => Callback]                                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                 js.UndefOr[ReactUIEventH => Callback]                                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                 js.UndefOr[ReactEventH => Callback]                                            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:            js.UndefOr[ReactTouchEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:               js.UndefOr[ReactTouchEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:              js.UndefOr[ReactTouchEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:             js.UndefOr[ReactTouchEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:          js.UndefOr[ReactTouchEventH => Callback]                                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                  js.UndefOr[ReactWheelEventH => Callback]                                       = js.undefined){
   /**
    * @param children The content of the menu. This is usually used to pass `MenuItem`
 elements.

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiMenuItem.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiMenuItem.scala
@@ -8,103 +8,179 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiMenuItem[T](
-  key:                         js.UndefOr[String]                          = js.undefined,
-  ref:                         js.UndefOr[MuiMenuItemM => Unit]            = js.undefined,
+  key:                         js.UndefOr[String]                             = js.undefined,
+  ref:                         js.UndefOr[MuiMenuItemM => Unit]               = js.undefined,
   /* If true, a left check mark will be rendered.*/
-  checked:                     js.UndefOr[Boolean]                         = js.undefined,
+  checked:                     js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the menu item will render with compact desktop
   styles.*/
-  desktop:                     js.UndefOr[Boolean]                         = js.undefined,
+  desktop:                     js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the menu item will be disabled.*/
-  disabled:                    js.UndefOr[Boolean]                         = js.undefined,
+  disabled:                    js.UndefOr[Boolean]                            = js.undefined,
   /* The focus state of the menu item. This prop is used to set the focus
   state of the underlying `ListItem`.*/
-  focusState:                  js.UndefOr[NoneFocusedKeyboard_focused]     = js.undefined,
+  focusState:                  js.UndefOr[NoneFocusedKeyboard_focused]        = js.undefined,
   /* Override the inline-styles of the inner div.*/
-  innerDivStyle:               js.UndefOr[CssProperties]                   = js.undefined,
+  innerDivStyle:               js.UndefOr[CssProperties]                      = js.undefined,
   /* If true, the children will be indented.
   This is only needed when there is no `leftIcon`.*/
-  insetChildren:               js.UndefOr[Boolean]                         = js.undefined,
+  insetChildren:               js.UndefOr[Boolean]                            = js.undefined,
   /* The `SvgIcon` or `FontIcon` to be displayed on the left side.*/
-  leftIcon:                    js.UndefOr[ReactElement]                    = js.undefined,
+  leftIcon:                    js.UndefOr[ReactElement]                       = js.undefined,
   /* `MenuItem` elements to nest within the menu item.*/
-  menuItems:                   js.UndefOr[ReactNode]                       = js.undefined,
+  menuItems:                   js.UndefOr[ReactNode]                          = js.undefined,
   /* Callback function fired when the menu item is touch-tapped.*/
-  onTouchTap:                  js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchTap:                  js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* Can be used to render primary text within the menu item.*/
-  primaryText:                 js.UndefOr[ReactNode]                       = js.undefined,
+  primaryText:                 js.UndefOr[ReactNode]                          = js.undefined,
   /* The `SvgIcon` or `FontIcon` to be displayed on the right side.*/
-  rightIcon:                   js.UndefOr[ReactElement]                    = js.undefined,
+  rightIcon:                   js.UndefOr[ReactElement]                       = js.undefined,
   /* Can be used to render secondary text within the menu item.*/
-  secondaryText:               js.UndefOr[ReactNode]                       = js.undefined,
+  secondaryText:               js.UndefOr[ReactNode]                          = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                       js.UndefOr[CssProperties]                   = js.undefined,
+  style:                       js.UndefOr[CssProperties]                      = js.undefined,
   /* The value of the menu item.*/
-  value:                       js.UndefOr[T]                               = js.undefined,
+  value:                       js.UndefOr[T]                                  = js.undefined,
   /* If true, generate a nested-list-indicator icon when nested list
   items are detected. Note that an indicator will not be created
   if a `rightIcon` or `rightIconButton` has been provided to
   the element.
   (Passed on to ListItem)*/
-  autoGenerateNestedIndicator: js.UndefOr[Boolean]                         = js.undefined,
+  autoGenerateNestedIndicator: js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the element will not be able to be focused by the keyboard.
   (Passed on to ListItem)*/
-  disableKeyboardFocus:        js.UndefOr[Boolean]                         = js.undefined,
+  disableKeyboardFocus:        js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the nested `ListItem`s are initially displayed.
   (Passed on to ListItem)*/
-  initiallyOpen:               js.UndefOr[Boolean]                         = js.undefined,
+  initiallyOpen:               js.UndefOr[Boolean]                            = js.undefined,
   /* This is the `Avatar` element to be displayed on the left side.
   (Passed on to ListItem)*/
-  leftAvatar:                  js.UndefOr[ReactElement]                    = js.undefined,
+  leftAvatar:                  js.UndefOr[ReactElement]                       = js.undefined,
   /* This is the `Checkbox` element to be displayed on the left side.
   (Passed on to ListItem)*/
-  leftCheckbox:                js.UndefOr[ReactElement]                    = js.undefined,
+  leftCheckbox:                js.UndefOr[ReactElement]                       = js.undefined,
   /* An array of `ListItem`s to nest underneath the current `ListItem`.
   (Passed on to ListItem)*/
-  nestedItems:                 js.UndefOr[js.Array[ReactElement]]          = js.undefined,
+  nestedItems:                 js.UndefOr[js.Array[ReactElement]]             = js.undefined,
   /* Controls how deep a `ListItem` appears.
   This property is automatically managed, so modify at your own risk.
   (Passed on to ListItem)*/
-  nestedLevel:                 js.UndefOr[Int]                             = js.undefined,
+  nestedLevel:                 js.UndefOr[Int]                                = js.undefined,
   /* Override the inline-styles of the nested items' `NestedList`.
   (Passed on to ListItem)*/
-  nestedListStyle:             js.UndefOr[CssProperties]                   = js.undefined,
+  nestedListStyle:             js.UndefOr[CssProperties]                      = js.undefined,
   /* Callback function fired when the `ListItem` is focused or blurred by the keyboard.
   (Passed on to ListItem)*/
-  onKeyboardFocus:             js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyboardFocus:             js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* 
   (Passed on to ListItem)*/
-  onMouseEnter:                js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseEnter:                js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* 
   (Passed on to ListItem)*/
-  onMouseLeave:                js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseLeave:                js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* Callbak function fired when the `ListItem` toggles its nested list.
   (Passed on to ListItem)*/
-  onNestedListToggle:          js.UndefOr[js.Any => Callback]              = js.undefined,
+  onNestedListToggle:          js.UndefOr[js.Any => Callback]                 = js.undefined,
   /* 
   (Passed on to ListItem)*/
-  onTouchStart:                js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchStart:                js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* If true, clicking or tapping the primary text of the `ListItem`
   toggles the nested list.
   (Passed on to ListItem)*/
-  primaryTogglesNestedList:    js.UndefOr[Boolean]                         = js.undefined,
+  primaryTogglesNestedList:    js.UndefOr[Boolean]                            = js.undefined,
   /* This is the `Avatar` element to be displayed on the right side.
   (Passed on to ListItem)*/
-  rightAvatar:                 js.UndefOr[ReactElement]                    = js.undefined,
+  rightAvatar:                 js.UndefOr[ReactElement]                       = js.undefined,
   /* This is the `IconButton` to be displayed on the right side.
   Hovering over this button will remove the `ListItem` hover.
   Also, clicking on this button will not trigger a
   ripple on the `ListItem`; the event will be stopped and prevented
   from bubbling up to cause a `ListItem` click.
   (Passed on to ListItem)*/
-  rightIconButton:             js.UndefOr[ReactElement]                    = js.undefined,
+  rightIconButton:             js.UndefOr[ReactElement]                       = js.undefined,
   /* This is the `Toggle` element to display on the right side.
   (Passed on to ListItem)*/
-  rightToggle:                 js.UndefOr[ReactElement]                    = js.undefined,
+  rightToggle:                 js.UndefOr[ReactElement]                       = js.undefined,
   /* Can be 1 or 2. This is the number of secondary
   text lines before ellipsis will show.
   (Passed on to ListItem)*/
-  secondaryTextLines:          js.UndefOr[_1_2]                            = js.undefined){
+  secondaryTextLines:          js.UndefOr[_1_2]                               = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:              js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:            js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:                      js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:                    js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                     js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:            js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:          js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:         js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:               js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                      js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                       js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:               js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                      js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:                   js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:                  js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:                  js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                      js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:                     js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                     js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:                   js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:                  js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                     js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:                 js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:                 js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:                   js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                     js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                    js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                    js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                    js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:               js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:                  js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:                 js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:             js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                     js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Elements passed as children to the underlying `ListItem`.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiMuiThemeProvider.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiMuiThemeProvider.scala
@@ -8,9 +8,91 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiMuiThemeProvider(
-  key:      js.UndefOr[String]                       = js.undefined,
-  ref:      js.UndefOr[MuiMuiThemeProviderM => Unit] = js.undefined,
-  muiTheme: js.UndefOr[MuiTheme]                     = js.undefined){
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiMuiThemeProviderM => Unit]       = js.undefined,
+  muiTheme:             js.UndefOr[MuiTheme]                           = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply(children: ReactElement*) = {
     val props = JSMacro[MuiMuiThemeProvider](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.MuiThemeProvider)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiPaper.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiPaper.scala
@@ -8,19 +8,101 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiPaper(
-  key:               js.UndefOr[String]        = js.undefined,
-  ref:               js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* Set to true to generate a circlular paper container.*/
-  circle:            js.UndefOr[Boolean]       = js.undefined,
+  circle:               js.UndefOr[Boolean]                            = js.undefined,
   /* By default, the paper container will have a border radius.
   Set this to false to generate a container with sharp corners.*/
-  rounded:           js.UndefOr[Boolean]       = js.undefined,
+  rounded:              js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:             js.UndefOr[CssProperties] = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* Set to false to disable CSS transitions for the paper element.*/
-  transitionEnabled: js.UndefOr[Boolean]       = js.undefined,
+  transitionEnabled:    js.UndefOr[Boolean]                            = js.undefined,
   /* This number represents the zDepth of the paper shadow.*/
-  zDepth:            js.UndefOr[ZDepth]        = js.undefined){
+  zDepth:               js.UndefOr[ZDepth]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Children passed into the paper element.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiPopover.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiPopover.scala
@@ -8,49 +8,131 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiPopover(
-  key:                    js.UndefOr[String]              = js.undefined,
-  ref:                    js.UndefOr[MuiPopoverM => Unit] = js.undefined,
+  key:                    js.UndefOr[String]                             = js.undefined,
+  ref:                    js.UndefOr[MuiPopoverM => Unit]                = js.undefined,
   /* This is the DOM element that will be used to set the position of the
   popover.*/
-  anchorEl:               js.UndefOr[js.Any]              = js.undefined,
+  anchorEl:               js.UndefOr[js.Any]                             = js.undefined,
   /* This is the point on the anchor where the popover's
   `targetOrigin` will attach to.
   Options:
   vertical: [top, middle, bottom];
   horizontal: [left, center, right].*/
-  anchorOrigin:           js.UndefOr[Origin]              = js.undefined,
+  anchorOrigin:           js.UndefOr[Origin]                             = js.undefined,
   /* If true, the popover will apply transitions when
   it is added to the DOM.*/
-  animated:               js.UndefOr[Boolean]             = js.undefined,
+  animated:               js.UndefOr[Boolean]                            = js.undefined,
   /* Override the default animation component used.*/
-  animation:              js.UndefOr[js.Any]              = js.undefined,
+  animation:              js.UndefOr[js.Any]                             = js.undefined,
   /* If true, the popover will hide when the anchor is scrolled off the screen.*/
-  autoCloseWhenOffScreen: js.UndefOr[Boolean]             = js.undefined,
+  autoCloseWhenOffScreen: js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the popover (potentially) ignores `targetOrigin`
   and `anchorOrigin` to make itself fit on screen,
   which is useful for mobile devices.*/
-  canAutoPosition:        js.UndefOr[Boolean]             = js.undefined,
+  canAutoPosition:        js.UndefOr[Boolean]                            = js.undefined,
   /* The CSS class name of the root element.*/
-  className:              js.UndefOr[String]              = js.undefined,
+  className:              js.UndefOr[String]                             = js.undefined,
   /* Callback function fired when the popover is requested to be closed.
   are 'clickAway' and 'offScreen'.*/
-  onRequestClose:         js.UndefOr[Callback]            = js.undefined,
+  onRequestClose:         js.UndefOr[Callback]                           = js.undefined,
   /* If true, the popover is visible.*/
-  open:                   js.UndefOr[Boolean]             = js.undefined,
+  open:                   js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                  js.UndefOr[CssProperties]       = js.undefined,
+  style:                  js.UndefOr[CssProperties]                      = js.undefined,
   /* This is the point on the popover which will attach to
   the anchor's origin.
   Options:
   vertical: [top, middle, bottom];
   horizontal: [left, center, right].*/
-  targetOrigin:           js.UndefOr[Origin]              = js.undefined,
+  targetOrigin:           js.UndefOr[Origin]                             = js.undefined,
   /* If true, the popover will render on top of an invisible
   layer, which will prevent clicks to the underlying
   elements, and trigger an `onRequestClose('clickAway')` call.*/
-  useLayerForClickAway:   js.UndefOr[Boolean]             = js.undefined,
+  useLayerForClickAway:   js.UndefOr[Boolean]                            = js.undefined,
   /* The zDepth of the popover.*/
-  zDepth:                 js.UndefOr[ZDepth]              = js.undefined){
+  zDepth:                 js.UndefOr[ZDepth]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:         js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:   js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:                 js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:               js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:       js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:    js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:          js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                 js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                  js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:              js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:             js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:             js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:                js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:             js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:           js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:           js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:               js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:               js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:               js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:             js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:            js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children The content of the popover.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiPopoverAnimationVertical.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiPopoverAnimationVertical.scala
@@ -8,14 +8,96 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiPopoverAnimationVertical(
-  key:          js.UndefOr[String]        = js.undefined,
-  ref:          js.UndefOr[String]        = js.undefined,
-  className:    js.UndefOr[String]        = js.undefined,
-  open:         Boolean,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
+  open:                 Boolean,
   /* Override the inline-styles of the root element.*/
-  style:        js.UndefOr[CssProperties] = js.undefined,
-  targetOrigin: js.UndefOr[Origin]        = js.undefined,
-  zDepth:       js.UndefOr[ZDepth]        = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  targetOrigin:         js.UndefOr[Origin]                             = js.undefined,
+  zDepth:               js.UndefOr[ZDepth]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply(children: ReactNode*) = {
     val props = JSMacro[MuiPopoverAnimationVertical](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.PopoverAnimationVertical)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiRadioButton.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiRadioButton.scala
@@ -80,7 +80,75 @@ case class MuiRadioButton[T](
   /* (Passed on to EnhancedSwitch)*/
   thumbStyle:           js.UndefOr[CssProperties]                      = js.undefined,
   /* (Passed on to EnhancedSwitch)*/
-  trackStyle:           js.UndefOr[CssProperties]                      = js.undefined){
+  trackStyle:           js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     implicit def evT(t: T): js.Any = t.asInstanceOf[js.Any]
     val props = JSMacro[MuiRadioButton[T]](this)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiRadioButtonGroup.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiRadioButtonGroup.scala
@@ -8,59 +8,139 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiRadioButtonGroup[T](
-  key:             js.UndefOr[String]                             = js.undefined,
-  ref:             js.UndefOr[MuiRadioButtonGroupM => Unit]       = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiRadioButtonGroupM => Unit]       = js.undefined,
   /* The CSS class name of the root element.*/
-  className:       js.UndefOr[String]                             = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* The `value` property (case-sensitive) of the radio button that will be
   selected by default. This takes precedence over the `checked` property
   of the `RadioButton` elements.*/
-  defaultSelected: js.UndefOr[String]                             = js.undefined,
+  defaultSelected:      js.UndefOr[String]                             = js.undefined,
   /* Where the label will be placed for all child radio buttons.
   This takes precedence over the `labelPosition` property of the
   `RadioButton` elements.*/
-  labelPosition:   js.UndefOr[LeftRight]                          = js.undefined,
+  labelPosition:        js.UndefOr[LeftRight]                          = js.undefined,
   /* The name that will be applied to all child radio buttons.*/
-  name:            String,
+  name:                 String,
   /* Callback function that is fired when a radio button has
   been checked.
   radio button.*/
-  onChange:        js.UndefOr[(ReactEventI, String) => Callback]  = js.undefined,
+  onChange:             js.UndefOr[(ReactEventI, String) => Callback]  = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:           js.UndefOr[CssProperties]                      = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The `value` of the currently selected radio button.*/
-  valueSelected:   js.UndefOr[String]                             = js.undefined,
+  valueSelected:        js.UndefOr[String]                             = js.undefined,
   /* checked if true
   Used internally by `RadioButtonGroup`.
   (Passed on to RadioButton)*/
-  checked:         js.UndefOr[Boolean]                            = js.undefined,
+  checked:              js.UndefOr[Boolean]                            = js.undefined,
   /* The icon element to show when the radio button is checked.
   (Passed on to RadioButton)*/
-  checkedIcon:     js.UndefOr[ReactElement]                       = js.undefined,
+  checkedIcon:          js.UndefOr[ReactElement]                       = js.undefined,
   /* If true, the radio button is disabled.
   (Passed on to RadioButton)*/
-  disabled:        js.UndefOr[Boolean]                            = js.undefined,
+  disabled:             js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the icon element.
   (Passed on to RadioButton)*/
-  iconStyle:       js.UndefOr[CssProperties]                      = js.undefined,
+  iconStyle:            js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the input element.
   (Passed on to RadioButton)*/
-  inputStyle:      js.UndefOr[CssProperties]                      = js.undefined,
+  inputStyle:           js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the label element.
   (Passed on to RadioButton)*/
-  labelStyle:      js.UndefOr[CssProperties]                      = js.undefined,
+  labelStyle:           js.UndefOr[CssProperties]                      = js.undefined,
   /* Callback function fired when the radio button is checked. Note that this
   function will not be called if the radio button is part of a
   radio button group: in this case, use the `onChange` property of
   `RadioButtonGroup`.
   (Passed on to RadioButton)*/
-  onCheck:         js.UndefOr[(ReactEventH, Boolean) => Callback] = js.undefined,
+  onCheck:              js.UndefOr[(ReactEventH, Boolean) => Callback] = js.undefined,
   /* The icon element to show when the radio button is unchecked.
   (Passed on to RadioButton)*/
-  uncheckedIcon:   js.UndefOr[ReactElement]                       = js.undefined,
+  uncheckedIcon:        js.UndefOr[ReactElement]                       = js.undefined,
   /* The value of the radio button.
   (Passed on to RadioButton)*/
-  value:           js.UndefOr[T]                                  = js.undefined){
+  value:                js.UndefOr[T]                                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Should be used to pass `RadioButton` components.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiRaisedButton.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiRaisedButton.scala
@@ -8,94 +8,154 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiRaisedButton(
-  key:                     js.UndefOr[String]                          = js.undefined,
-  ref:                     js.UndefOr[String]                          = js.undefined,
+  key:                     js.UndefOr[String]                             = js.undefined,
+  ref:                     js.UndefOr[String]                             = js.undefined,
   /* Override the default background color for the button,
   but not the default disabled background color
   (use `disabledBackgroundColor` for this).*/
-  backgroundColor:         js.UndefOr[MuiColor]                        = js.undefined,
+  backgroundColor:         js.UndefOr[MuiColor]                           = js.undefined,
   /* The CSS class name of the root element.*/
-  className:               js.UndefOr[String]                          = js.undefined,
+  className:               js.UndefOr[String]                             = js.undefined,
   /* If true, the button will be disabled.*/
-  disabled:                js.UndefOr[Boolean]                         = js.undefined,
+  disabled:                js.UndefOr[Boolean]                            = js.undefined,
   /* Override the default background color for the button
   when it is disabled.*/
-  disabledBackgroundColor: js.UndefOr[MuiColor]                        = js.undefined,
+  disabledBackgroundColor: js.UndefOr[MuiColor]                           = js.undefined,
   /* The color of the button's label when the button is disabled.*/
-  disabledLabelColor:      js.UndefOr[MuiColor]                        = js.undefined,
+  disabledLabelColor:      js.UndefOr[MuiColor]                           = js.undefined,
   /* If true, the button will take up the full width of its container.*/
-  fullWidth:               js.UndefOr[Boolean]                         = js.undefined,
+  fullWidth:               js.UndefOr[Boolean]                            = js.undefined,
   /* The URL to link to when the button is clicked.*/
-  href:                    js.UndefOr[String]                          = js.undefined,
+  href:                    js.UndefOr[String]                             = js.undefined,
   /* An icon to be displayed within the button.*/
-  icon:                    js.UndefOr[ReactNode]                       = js.undefined,
+  icon:                    js.UndefOr[ReactNode]                          = js.undefined,
   /* The label to be displayed within the button.
   If content is provided via the `children` prop, that content will be
   displayed in addition to the label provided here.*/
-  label:                   js.UndefOr[String]                          = js.undefined,
+  label:                   js.UndefOr[String]                             = js.undefined,
   /* The color of the button's label.*/
-  labelColor:              js.UndefOr[MuiColor]                        = js.undefined,
+  labelColor:              js.UndefOr[MuiColor]                           = js.undefined,
   /* The position of the button's label relative to the button's `children`.*/
-  labelPosition:           js.UndefOr[BeforeAfter]                     = js.undefined,
+  labelPosition:           js.UndefOr[BeforeAfter]                        = js.undefined,
   /* Override the inline-styles of the button's label element.*/
-  labelStyle:              js.UndefOr[CssProperties]                   = js.undefined,
-  onMouseDown:             js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onMouseEnter:            js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onMouseLeave:            js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onMouseUp:               js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
-  onTouchEnd:              js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
-  onTouchStart:            js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  labelStyle:              js.UndefOr[CssProperties]                      = js.undefined,
+  onMouseDown:             js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseEnter:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseLeave:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onMouseUp:               js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  onTouchEnd:              js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  onTouchStart:            js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* If true, the button will use the theme's primary color.*/
-  primary:                 js.UndefOr[Boolean]                         = js.undefined,
+  primary:                 js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline style of the ripple element.*/
-  rippleStyle:             js.UndefOr[CssProperties]                   = js.undefined,
+  rippleStyle:             js.UndefOr[CssProperties]                      = js.undefined,
   /* If true, the button will use the theme's secondary color.
   If both `secondary` and `primary` are true, the button will use
   the theme's primary color.*/
-  secondary:               js.UndefOr[Boolean]                         = js.undefined,
+  secondary:               js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                   js.UndefOr[CssProperties]                   = js.undefined,
+  style:                   js.UndefOr[CssProperties]                      = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  centerRipple:            js.UndefOr[Boolean]                         = js.undefined,
+  centerRipple:            js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  containerElement:        js.UndefOr[String | ReactElement]           = js.undefined,
+  containerElement:        js.UndefOr[String | ReactElement]              = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableFocusRipple:      js.UndefOr[Boolean]                         = js.undefined,
+  disableFocusRipple:      js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableKeyboardFocus:    js.UndefOr[Boolean]                         = js.undefined,
+  disableKeyboardFocus:    js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableTouchRipple:      js.UndefOr[Boolean]                         = js.undefined,
+  disableTouchRipple:      js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleColor:        js.UndefOr[MuiColor]                        = js.undefined,
+  focusRippleColor:        js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleOpacity:      js.UndefOr[Double]                          = js.undefined,
+  focusRippleOpacity:      js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  keyboardFocused:         js.UndefOr[Boolean]                         = js.undefined,
+  keyboardFocused:         js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
   @deprecated("LinkButton is no longer required when the `href` property is provided.\n      It will be removed with v0.16.0.")
-  linkButton:              js.UndefOr[Boolean]                         = js.undefined,
+  linkButton:              js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onBlur:                  js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  onBlur:                  js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onClick:                 js.UndefOr[ReactEventH => Callback]         = js.undefined,
+  onClick:                 js.UndefOr[ReactEventH => Callback]            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onFocus:                 js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  onFocus:                 js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyDown:               js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyDown:               js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyUp:                 js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyUp:                 js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyboardFocus:         js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyboardFocus:         js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onTouchTap:              js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchTap:              js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  tabIndex:                js.UndefOr[Double]                          = js.undefined,
+  tabIndex:                js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleColor:        js.UndefOr[MuiColor]                        = js.undefined,
+  touchRippleColor:        js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleOpacity:      js.UndefOr[Double]                          = js.undefined,
+  touchRippleOpacity:      js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  `type`:                  js.UndefOr[String]                          = js.undefined){
+  `type`:                  js.UndefOr[String]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:          js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:    js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:                js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:        js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:      js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:           js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                  js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                   js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:           js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                  js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:             js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:              js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:             js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:              js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:             js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                  js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                 js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:             js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                 js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:             js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                 js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children The content of the button.
 If a label is provided via the `label` prop, the text within the label

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiRefreshIndicator.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiRefreshIndicator.scala
@@ -8,30 +8,112 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiRefreshIndicator(
-  key:          js.UndefOr[String]                       = js.undefined,
-  ref:          js.UndefOr[MuiRefreshIndicatorM => Unit] = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiRefreshIndicatorM => Unit]       = js.undefined,
   /* Override the theme's color of the indicator while it's status is
   "ready" and it's percentage is less than 100.*/
-  color:        js.UndefOr[MuiColor]                     = js.undefined,
+  color:                js.UndefOr[MuiColor]                           = js.undefined,
   /* The absolute left position of the indicator in pixels.*/
-  left:         Int,
+  left:                 Int,
   /* Override the theme's color of the indicator while
   it's status is "loading" or when it's percentage is 100.*/
-  loadingColor: js.UndefOr[MuiColor]                     = js.undefined,
+  loadingColor:         js.UndefOr[MuiColor]                           = js.undefined,
   /* The confirmation progress to fetch data. Max value is 100.*/
-  percentage:   js.UndefOr[Double]                       = js.undefined,
+  percentage:           js.UndefOr[Double]                             = js.undefined,
   /* Size in pixels.*/
-  size:         js.UndefOr[Int]                          = js.undefined,
+  size:                 js.UndefOr[Int]                                = js.undefined,
   /* The display status of the indicator. If the status is
   "ready", the indicator will display the ready state
   arrow. If the status is "loading", it will display
   the loading progress indicator. If the status is "hide",
   the indicator will be hidden.*/
-  status:       js.UndefOr[ReadyLoadingHide]             = js.undefined,
+  status:               js.UndefOr[ReadyLoadingHide]                   = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:        js.UndefOr[CssProperties]                = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The absolute top position of the indicator in pixels.*/
-  top:          Int){
+  top:                  Int,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     val props = JSMacro[MuiRefreshIndicator](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.RefreshIndicator)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiSelectField.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiSelectField.scala
@@ -8,73 +8,149 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiSelectField[T](
-  key:                    js.UndefOr[String]                            = js.undefined,
-  ref:                    js.UndefOr[String]                            = js.undefined,
+  key:                    js.UndefOr[String]                             = js.undefined,
+  ref:                    js.UndefOr[String]                             = js.undefined,
   /* If true, the width will automatically be set according to the
   items inside the menu.
   To control the width in CSS instead, leave this prop set to `false`.*/
-  autoWidth:              js.UndefOr[Boolean]                           = js.undefined,
+  autoWidth:              js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the select field will be disabled.*/
-  disabled:               js.UndefOr[Boolean]                           = js.undefined,
+  disabled:               js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the error element.*/
-  errorStyle:             js.UndefOr[CssProperties]                     = js.undefined,
+  errorStyle:             js.UndefOr[CssProperties]                      = js.undefined,
   /* The error content to display.*/
-  errorText:              js.UndefOr[ReactNode]                         = js.undefined,
+  errorText:              js.UndefOr[ReactNode]                          = js.undefined,
   /* If true, the floating label will float even when no value is selected.*/
-  floatingLabelFixed:     js.UndefOr[Boolean]                           = js.undefined,
+  floatingLabelFixed:     js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the floating label.*/
-  floatingLabelStyle:     js.UndefOr[CssProperties]                     = js.undefined,
+  floatingLabelStyle:     js.UndefOr[CssProperties]                      = js.undefined,
   /* The content of the floating label.*/
-  floatingLabelText:      js.UndefOr[ReactNode]                         = js.undefined,
+  floatingLabelText:      js.UndefOr[ReactNode]                          = js.undefined,
   /* If true, the select field will take up the full width of its container.*/
-  fullWidth:              js.UndefOr[Boolean]                           = js.undefined,
+  fullWidth:              js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the hint element.*/
-  hintStyle:              js.UndefOr[CssProperties]                     = js.undefined,
+  hintStyle:              js.UndefOr[CssProperties]                      = js.undefined,
   /* The hint content to display.*/
-  hintText:               js.UndefOr[ReactNode]                         = js.undefined,
+  hintText:               js.UndefOr[ReactNode]                          = js.undefined,
   /* Override the inline-styles of the icon element.*/
-  iconStyle:              js.UndefOr[CssProperties]                     = js.undefined,
+  iconStyle:              js.UndefOr[CssProperties]                      = js.undefined,
   /* The id prop for the text field.*/
-  id:                     js.UndefOr[String]                            = js.undefined,
+  id:                     js.UndefOr[String]                             = js.undefined,
   /* Override the label style when the select field is inactive.*/
-  labelStyle:             js.UndefOr[CssProperties]                     = js.undefined,
+  labelStyle:             js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the default max-height of the underlying `DropDownMenu` element.*/
-  maxHeight:              js.UndefOr[Int]                               = js.undefined,
+  maxHeight:              js.UndefOr[Int]                                = js.undefined,
   /* Override the inline-styles of the underlying `DropDownMenu` element.*/
-  menuStyle:              js.UndefOr[CssProperties]                     = js.undefined,
-  onBlur:                 js.UndefOr[ReactFocusEventH => Callback]      = js.undefined,
+  menuStyle:              js.UndefOr[CssProperties]                      = js.undefined,
+  onBlur:                 js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* Callback function fired when a menu item is selected.
   that was selected.*/
-  onChange:               js.UndefOr[(ReactEventI, Int, T) => Callback] = js.undefined,
-  onFocus:                js.UndefOr[ReactFocusEventH => Callback]      = js.undefined,
+  onChange:               js.UndefOr[(ReactEventI, Int, T) => Callback]  = js.undefined,
+  onFocus:                js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* Override the inline-styles of the underlying `DropDownMenu` element.*/
   @deprecated("Instead, use `menuStyle`. It will be removed with v0.16.0.")
-  selectFieldRoot:        js.UndefOr[CssProperties]                     = js.undefined,
+  selectFieldRoot:        js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                  js.UndefOr[CssProperties]                     = js.undefined,
+  style:                  js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the underline element when the select
   field is disabled.*/
-  underlineDisabledStyle: js.UndefOr[CssProperties]                     = js.undefined,
+  underlineDisabledStyle: js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the underline element when the select field
   is focused.*/
-  underlineFocusStyle:    js.UndefOr[CssProperties]                     = js.undefined,
+  underlineFocusStyle:    js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the underline element.*/
-  underlineStyle:         js.UndefOr[CssProperties]                     = js.undefined,
+  underlineStyle:         js.UndefOr[CssProperties]                      = js.undefined,
   /* The value that is currently selected.*/
-  value:                  js.UndefOr[T]                                 = js.undefined,
+  value:                  js.UndefOr[T]                                  = js.undefined,
   /* If true, the popover will apply transitions when
   it gets added to the DOM.
   (Passed on to DropDownMenu)*/
-  animated:               js.UndefOr[Boolean]                           = js.undefined,
+  animated:               js.UndefOr[Boolean]                            = js.undefined,
   /* The css class name of the root element.
   (Passed on to DropDownMenu)*/
-  className:              js.UndefOr[String]                            = js.undefined,
+  className:              js.UndefOr[String]                             = js.undefined,
   /* The style object to use to override underlying list style.
   (Passed on to DropDownMenu)*/
-  listStyle:              js.UndefOr[CssProperties]                     = js.undefined,
+  listStyle:              js.UndefOr[CssProperties]                      = js.undefined,
   /* Set to true to have the `DropDownMenu` automatically open on mount.
   (Passed on to DropDownMenu)*/
-  openImmediately:        js.UndefOr[Boolean]                           = js.undefined){
+  openImmediately:        js.UndefOr[Boolean]                            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:         js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:   js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:       js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:    js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:          js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                 js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                  js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:              js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:             js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:             js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                 js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:             js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:           js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:           js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:               js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:               js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:               js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:             js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:            js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children The `MenuItem` elements to populate the select field with.
 If the menu items have a `label` prop, that value will

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiSlider.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiSlider.scala
@@ -8,47 +8,121 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiSlider(
-  key:                js.UndefOr[String]                            = js.undefined,
-  ref:                js.UndefOr[MuiSliderM => Unit]                = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiSliderM => Unit]                 = js.undefined,
   /* The axis on which the slider will slide.*/
-  axis:               js.UndefOr[XX_reverseYY_reverse]              = js.undefined,
+  axis:                 js.UndefOr[XX_reverseYY_reverse]               = js.undefined,
   /* The default value of the slider.*/
-  defaultValue:       js.UndefOr[Double]                            = js.undefined,
+  defaultValue:         js.UndefOr[Double]                             = js.undefined,
   /* Describe the slider.*/
-  description:        js.UndefOr[String]                            = js.undefined,
+  description:          js.UndefOr[String]                             = js.undefined,
   /* Disables focus ripple if set to true.*/
-  disableFocusRipple: js.UndefOr[Boolean]                           = js.undefined,
+  disableFocusRipple:   js.UndefOr[Boolean]                            = js.undefined,
   /* If true, the slider will not be interactable.*/
-  disabled:           js.UndefOr[Boolean]                           = js.undefined,
+  disabled:             js.UndefOr[Boolean]                            = js.undefined,
   /* An error message for the slider.*/
-  error:              js.UndefOr[String]                            = js.undefined,
+  error:                js.UndefOr[String]                             = js.undefined,
   /* The maximum value the slider can slide to on
   a scale from 0 to 1 inclusive. Cannot be equal to min.*/
-  max:                js.UndefOr[Double]                            = js.undefined,
+  max:                  js.UndefOr[Double]                             = js.undefined,
   /* The minimum value the slider can slide to on a scale
   from 0 to 1 inclusive. Cannot be equal to max.*/
-  min:                js.UndefOr[Double]                            = js.undefined,
+  min:                  js.UndefOr[Double]                             = js.undefined,
   /* The name of the slider. Behaves like the name attribute
   of an input element.*/
-  name:               js.UndefOr[String]                            = js.undefined,
-  onBlur:             js.UndefOr[ReactFocusEventH => Callback]      = js.undefined,
+  name:                 js.UndefOr[String]                             = js.undefined,
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* Callback function that is fired when the user changes the slider's value.*/
-  onChange:           js.UndefOr[(ReactEventH, Double) => Callback] = js.undefined,
+  onChange:             js.UndefOr[(ReactEventH, Double) => Callback]  = js.undefined,
   /* Callback function that is fired when the slider has begun to move.*/
-  onDragStart:        js.UndefOr[ReactDragEventH => Callback]       = js.undefined,
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
   /* Callback function that is fried when the slide has stopped moving.*/
-  onDragStop:         js.UndefOr[ReactDragEventH => Callback]       = js.undefined,
-  onFocus:            js.UndefOr[ReactFocusEventH => Callback]      = js.undefined,
+  onDragStop:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* Whether or not the slider is required in a form.*/
-  required:           js.UndefOr[Boolean]                           = js.undefined,
+  required:             js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the inner slider element.*/
-  sliderStyle:        js.UndefOr[CssProperties]                     = js.undefined,
+  sliderStyle:          js.UndefOr[CssProperties]                      = js.undefined,
   /* The granularity the slider can step through values.*/
-  step:               js.UndefOr[Double]                            = js.undefined,
+  step:                 js.UndefOr[Double]                             = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:              js.UndefOr[CssProperties]                     = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The value of the slider.*/
-  value:              js.UndefOr[Double]                            = js.undefined){
+  value:                js.UndefOr[Double]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     val props = JSMacro[MuiSlider](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.Slider)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiSnackBar.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiSnackBar.scala
@@ -8,37 +8,119 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiSnackbar(
-  key:              js.UndefOr[String]                       = js.undefined,
-  ref:              js.UndefOr[MuiSnackbarM => Unit]         = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiSnackbarM => Unit]               = js.undefined,
   /* The label for the action on the snackbar.*/
-  action:           js.UndefOr[String]                       = js.undefined,
+  action:               js.UndefOr[String]                             = js.undefined,
   /* The number of milliseconds to wait before automatically dismissing.
   If no value is specified the snackbar will dismiss normally.
   If a value is provided the snackbar can still be dismissed normally.
   If a snackbar is dismissed before the timer expires, the timer will be cleared.*/
-  autoHideDuration: js.UndefOr[Int]                          = js.undefined,
+  autoHideDuration:     js.UndefOr[Int]                                = js.undefined,
   /* Override the inline-styles of the body element.*/
-  bodyStyle:        js.UndefOr[CssProperties]                = js.undefined,
+  bodyStyle:            js.UndefOr[CssProperties]                      = js.undefined,
   /* The css class name of the root element.*/
-  className:        js.UndefOr[String]                       = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* The message to be displayed.
   (Note: If the message is an element or array, and the `Snackbar` may re-render while it is still open,
   ensure that the same object remains as the `message` property if you want to avoid the `Snackbar` hiding and
   showing again)*/
-  message:          ReactNode,
+  message:              ReactNode,
   /* Fired when the action button is touchtapped.*/
-  onActionTouchTap: js.UndefOr[ReactTouchEventH => Callback] = js.undefined,
+  onActionTouchTap:     js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* Fired when the `Snackbar` is requested to be closed by a click outside the `Snackbar`, or after the
   `autoHideDuration` timer expires.
   Typically `onRequestClose` is used to set state in the parent component, which is used to control the `Snackbar`
   `open` prop.
   The `reason` parameter can optionally be used to control the response to `onRequestClose`,
   for example ignoring `clickaway`.*/
-  onRequestClose:   js.UndefOr[String => Callback]           = js.undefined,
+  onRequestClose:       js.UndefOr[String => Callback]                 = js.undefined,
   /* Controls whether the `Snackbar` is opened or not.*/
-  open:             Boolean,
+  open:                 Boolean,
   /* Override the inline-styles of the root element.*/
-  style:            js.UndefOr[CssProperties]                = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     val props = JSMacro[MuiSnackbar](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.Snackbar)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiStep.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiStep.scala
@@ -8,20 +8,102 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiStep(
-  key:       js.UndefOr[String]        = js.undefined,
-  ref:       js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* Sets the step as active. Is passed to child components.*/
-  active:    js.UndefOr[Boolean]       = js.undefined,
+  active:               js.UndefOr[Boolean]                            = js.undefined,
   /* Mark the step as completed. Is passed to child components.*/
-  completed: js.UndefOr[Boolean]       = js.undefined,
+  completed:            js.UndefOr[Boolean]                            = js.undefined,
   /* Mark the step as disabled, will also disable the button if
   `StepButton` is a child of `Step`. Is passed to child components.*/
-  disabled:  js.UndefOr[Boolean]       = js.undefined,
+  disabled:             js.UndefOr[Boolean]                            = js.undefined,
   /* Used internally for numbering.*/
-  index:     js.UndefOr[Double]        = js.undefined,
-  last:      js.UndefOr[Boolean]       = js.undefined,
+  index:                js.UndefOr[Double]                             = js.undefined,
+  last:                 js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-style of the root element.*/
-  style:     js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Should be `Step` sub-components such as `StepLabel`.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiStepContent.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiStepContent.scala
@@ -8,18 +8,100 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiStepContent(
-  key:                js.UndefOr[String]        = js.undefined,
-  ref:                js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* Expands the content*/
-  active:             js.UndefOr[Boolean]       = js.undefined,
-  completed:          js.UndefOr[Boolean]       = js.undefined,
-  last:               js.UndefOr[Boolean]       = js.undefined,
+  active:               js.UndefOr[Boolean]                            = js.undefined,
+  completed:            js.UndefOr[Boolean]                            = js.undefined,
+  last:                 js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-style of the root element.*/
-  style:              js.UndefOr[CssProperties] = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* ReactTransitionGroup component.*/
-  transition:         js.UndefOr[js.Any]        = js.undefined,
+  transition:           js.UndefOr[js.Any]                             = js.undefined,
   /* Adjust the duration of the content expand transition. Passed as a prop to the transition component.*/
-  transitionDuration: js.UndefOr[Double]        = js.undefined){
+  transitionDuration:   js.UndefOr[Double]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Step content
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiStepLabel.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiStepLabel.scala
@@ -8,19 +8,101 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiStepLabel(
-  key:       js.UndefOr[String]                         = js.undefined,
-  ref:       js.UndefOr[MuiStepLabelM => Unit]          = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiStepLabelM => Unit]              = js.undefined,
   /* Sets active styling. Overrides disabled coloring.*/
-  active:    js.UndefOr[Boolean]                        = js.undefined,
+  active:               js.UndefOr[Boolean]                            = js.undefined,
   /* Sets completed styling. Overrides disabled coloring.*/
-  completed: js.UndefOr[Boolean]                        = js.undefined,
+  completed:            js.UndefOr[Boolean]                            = js.undefined,
   /* Sets disabled styling.*/
-  disabled:  js.UndefOr[Boolean]                        = js.undefined,
+  disabled:             js.UndefOr[Boolean]                            = js.undefined,
   /* The icon displayed by the step label.*/
-  icon:      js.UndefOr[ReactElement | String | Double] = js.undefined,
-  last:      js.UndefOr[Boolean]                        = js.undefined,
+  icon:                 js.UndefOr[ReactElement | String | Double]     = js.undefined,
+  last:                 js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-style of the root element.*/
-  style:     js.UndefOr[CssProperties]                  = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children The label text node
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiStepper.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiStepper.scala
@@ -8,16 +8,98 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiStepper(
-  key:         js.UndefOr[String]                 = js.undefined,
-  ref:         js.UndefOr[MuiStepperM => Unit]    = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiStepperM => Unit]                = js.undefined,
   /* Set the active step (zero based index). This will enable `Step` control helpers.*/
-  activeStep:  js.UndefOr[Double]                 = js.undefined,
+  activeStep:           js.UndefOr[Double]                             = js.undefined,
   /* If set to `true`, the `Stepper` will assist in controlling steps for linear flow*/
-  linear:      js.UndefOr[Boolean]                = js.undefined,
+  linear:               js.UndefOr[Boolean]                            = js.undefined,
   /* The stepper orientation (layout flow direction)*/
-  orientation: js.UndefOr[HorizontalVertical]     = js.undefined,
+  orientation:          js.UndefOr[HorizontalVertical]                 = js.undefined,
   /* Override the inline-style of the root element.*/
-  style:       js.UndefOr[CssProperties]          = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Should be two or more `<Step />` components
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiSubheader.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiSubheader.scala
@@ -8,12 +8,94 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiSubheader(
-  key:      js.UndefOr[String]        = js.undefined,
-  ref:      js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* If true, the `Subheader` will be indented by `72px`.*/
-  inset:    js.UndefOr[Boolean]       = js.undefined,
+  inset:                js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:    js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Node that will be placed inside the `Subheader`.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTab.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTab.scala
@@ -8,87 +8,147 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiTab[T](
-  key:                  js.UndefOr[String]                          = js.undefined,
-  ref:                  js.UndefOr[String]                          = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* The css class name of the root element.*/
-  className:            js.UndefOr[String]                          = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* Sets the icon of the tab, you can pass `FontIcon` or `SvgIcon` elements.*/
-  icon:                 js.UndefOr[ReactNode]                       = js.undefined,
-  index:                js.UndefOr[js.Any]                          = js.undefined,
+  icon:                 js.UndefOr[ReactNode]                          = js.undefined,
+  index:                js.UndefOr[js.Any]                             = js.undefined,
   /* Sets the text value of the tab item to the string specified.*/
-  label:                js.UndefOr[ReactNode]                       = js.undefined,
+  label:                js.UndefOr[ReactNode]                          = js.undefined,
   /* Fired when the active tab changes by touch or tap.
   Use this event to specify any functionality when an active tab changes.
   For example - we are using this to route to home when the third tab becomes active.
   This function will always recieve the active tab as it\'s first argument.*/
-  onActive:             js.UndefOr[ReactElement => Callback]        = js.undefined,
+  onActive:             js.UndefOr[ReactElement => Callback]           = js.undefined,
   /* This property is overriden by the Tabs component.*/
-  onTouchTap:           js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchTap:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* Defines if the current tab is selected or not.
   The Tabs component is responsible for setting this property.*/
-  selected:             js.UndefOr[Boolean]                         = js.undefined,
+  selected:             js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                js.UndefOr[CssProperties]                   = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* If value prop passed to Tabs component, this value prop is also required.
   It assigns a value to the tab so that it can be selected by the Tabs.*/
-  value:                js.UndefOr[T]                               = js.undefined,
+  value:                js.UndefOr[T]                                  = js.undefined,
   /* This property is overriden by the Tabs component.*/
-  width:                js.UndefOr[String]                          = js.undefined,
+  width:                js.UndefOr[String]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  centerRipple:         js.UndefOr[Boolean]                         = js.undefined,
+  centerRipple:         js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  containerElement:     js.UndefOr[String | ReactElement]           = js.undefined,
+  containerElement:     js.UndefOr[String | ReactElement]              = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableFocusRipple:   js.UndefOr[Boolean]                         = js.undefined,
+  disableFocusRipple:   js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableKeyboardFocus: js.UndefOr[Boolean]                         = js.undefined,
+  disableKeyboardFocus: js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disableTouchRipple:   js.UndefOr[Boolean]                         = js.undefined,
+  disableTouchRipple:   js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  disabled:             js.UndefOr[Boolean]                         = js.undefined,
+  disabled:             js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleColor:     js.UndefOr[MuiColor]                        = js.undefined,
+  focusRippleColor:     js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  focusRippleOpacity:   js.UndefOr[Double]                          = js.undefined,
+  focusRippleOpacity:   js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  href:                 js.UndefOr[String]                          = js.undefined,
+  href:                 js.UndefOr[String]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  keyboardFocused:      js.UndefOr[Boolean]                         = js.undefined,
+  keyboardFocused:      js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
   @deprecated("LinkButton is no longer required when the `href` property is provided.\n      It will be removed with v0.16.0.")
-  linkButton:           js.UndefOr[Boolean]                         = js.undefined,
+  linkButton:           js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onBlur:               js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onClick:              js.UndefOr[ReactEventH => Callback]         = js.undefined,
+  onClick:              js.UndefOr[ReactEventH => Callback]            = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onFocus:              js.UndefOr[ReactFocusEventH => Callback]    = js.undefined,
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onKeyboardFocus:      js.UndefOr[ReactKeyboardEventH => Callback] = js.undefined,
+  onKeyboardFocus:      js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]    = js.undefined,
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]    = js.undefined,
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  tabIndex:             js.UndefOr[Double]                          = js.undefined,
+  tabIndex:             js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleColor:     js.UndefOr[MuiColor]                        = js.undefined,
+  touchRippleColor:     js.UndefOr[MuiColor]                           = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  touchRippleOpacity:   js.UndefOr[Double]                          = js.undefined,
+  touchRippleOpacity:   js.UndefOr[Double]                             = js.undefined,
   /* (Passed on to EnhancedButton)*/
-  `type`:               js.UndefOr[String]                          = js.undefined){
+  `type`:               js.UndefOr[String]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Should be used to pass `Tab` components.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTable.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTable.scala
@@ -8,61 +8,143 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiTable(
-  key:             js.UndefOr[String]                                    = js.undefined,
-  ref:             js.UndefOr[MuiTableM => Unit]                         = js.undefined,
+  key:                  js.UndefOr[String]                                    = js.undefined,
+  ref:                  js.UndefOr[MuiTableM => Unit]                         = js.undefined,
   /* Set to true to indicate that all rows should be selected.*/
-  allRowsSelected: js.UndefOr[Boolean]                                   = js.undefined,
+  allRowsSelected:      js.UndefOr[Boolean]                                   = js.undefined,
   /* Override the inline-styles of the body's table element.*/
-  bodyStyle:       js.UndefOr[CssProperties]                             = js.undefined,
+  bodyStyle:            js.UndefOr[CssProperties]                             = js.undefined,
   /* The css class name of the root element.*/
-  className:       js.UndefOr[String]                                    = js.undefined,
+  className:            js.UndefOr[String]                                    = js.undefined,
   /* If true, the footer will appear fixed below the table.
   The default value is true.*/
-  fixedFooter:     js.UndefOr[Boolean]                                   = js.undefined,
+  fixedFooter:          js.UndefOr[Boolean]                                   = js.undefined,
   /* If true, the header will appear fixed above the table.
   The default value is true.*/
-  fixedHeader:     js.UndefOr[Boolean]                                   = js.undefined,
+  fixedHeader:          js.UndefOr[Boolean]                                   = js.undefined,
   /* Override the inline-styles of the footer's table element.*/
-  footerStyle:     js.UndefOr[CssProperties]                             = js.undefined,
+  footerStyle:          js.UndefOr[CssProperties]                             = js.undefined,
   /* Override the inline-styles of the header's table element.*/
-  headerStyle:     js.UndefOr[CssProperties]                             = js.undefined,
+  headerStyle:          js.UndefOr[CssProperties]                             = js.undefined,
   /* The height of the table.*/
-  height:          js.UndefOr[String]                                    = js.undefined,
+  height:               js.UndefOr[String]                                    = js.undefined,
   /* If true, multiple table rows can be selected.
   CTRL/CMD+Click and SHIFT+Click are valid actions.
   The default value is false.*/
-  multiSelectable: js.UndefOr[Boolean]                                   = js.undefined,
+  multiSelectable:      js.UndefOr[Boolean]                                   = js.undefined,
   /* Called when a row cell is clicked.
   rowNumber is the row number and columnId is
   the column number or the column key.*/
-  onCellClick:     js.UndefOr[(RowId, ColumnId, ReactEvent) => Callback] = js.undefined,
+  onCellClick:          js.UndefOr[(RowId, ColumnId, ReactEvent) => Callback] = js.undefined,
   /* Called when a table cell is hovered.
   rowNumber is the row number of the hovered row
   and columnId is the column number or the column key of the cell.*/
-  onCellHover:     js.UndefOr[(RowId, ColumnId, ReactEvent) => Callback] = js.undefined,
+  onCellHover:          js.UndefOr[(RowId, ColumnId, ReactEvent) => Callback] = js.undefined,
   /* Called when a table cell is no longer hovered.
   rowNumber is the row number of the row and columnId
   is the column number or the column key of the cell.*/
-  onCellHoverExit: js.UndefOr[(RowId, ColumnId, ReactEvent) => Callback] = js.undefined,
+  onCellHoverExit:      js.UndefOr[(RowId, ColumnId, ReactEvent) => Callback] = js.undefined,
   /* Called when a table row is hovered.
   rowNumber is the row number of the hovered row.*/
-  onRowHover:      js.UndefOr[RowId => Callback]                         = js.undefined,
+  onRowHover:           js.UndefOr[RowId => Callback]                         = js.undefined,
   /* Called when a table row is no longer hovered.
   rowNumber is the row number of the row that is no longer hovered.*/
-  onRowHoverExit:  js.UndefOr[RowId => Callback]                         = js.undefined,
+  onRowHoverExit:       js.UndefOr[RowId => Callback]                         = js.undefined,
   /* Called when a row is selected.
   selectedRows is an array of all row selections.
   IF all rows have been selected, the string "all"
   will be returned instead to indicate that all rows have been selected.*/
-  onRowSelection:  js.UndefOr[String | js.Array[RowId] => Callback]      = js.undefined,
+  onRowSelection:       js.UndefOr[String | js.Array[RowId] => Callback]      = js.undefined,
   /* If true, table rows can be selected.
   If multiple row selection is desired, enable multiSelectable.
   The default value is true.*/
-  selectable:      js.UndefOr[Boolean]                                   = js.undefined,
+  selectable:           js.UndefOr[Boolean]                                   = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:           js.UndefOr[CssProperties]                             = js.undefined,
+  style:                js.UndefOr[CssProperties]                             = js.undefined,
   /* Override the inline-styles of the table's wrapper element.*/
-  wrapperStyle:    js.UndefOr[CssProperties]                             = js.undefined){
+  wrapperStyle:         js.UndefOr[CssProperties]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]              = js.undefined){
   /**
    * @param children Children passed to table.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableBody.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableBody.scala
@@ -8,60 +8,142 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiTableBody(
-  key:                 js.UndefOr[String]                                    = js.undefined,
-  ref:                 js.UndefOr[MuiTableBodyM => Unit]                     = js.undefined,
+  key:                  js.UndefOr[String]                                    = js.undefined,
+  ref:                  js.UndefOr[MuiTableBodyM => Unit]                     = js.undefined,
   /* Set to true to indicate that all rows should be selected.*/
-  allRowsSelected:     js.UndefOr[Boolean]                                   = js.undefined,
+  allRowsSelected:      js.UndefOr[Boolean]                                   = js.undefined,
   /* The css class name of the root element.*/
-  className:           js.UndefOr[String]                                    = js.undefined,
+  className:            js.UndefOr[String]                                    = js.undefined,
   /* Controls whether or not to deselect all selected
   rows after clicking outside the table.*/
-  deselectOnClickaway: js.UndefOr[Boolean]                                   = js.undefined,
+  deselectOnClickaway:  js.UndefOr[Boolean]                                   = js.undefined,
   /* Controls the display of the row checkbox. The default value is true.*/
-  displayRowCheckbox:  js.UndefOr[Boolean]                                   = js.undefined,
+  displayRowCheckbox:   js.UndefOr[Boolean]                                   = js.undefined,
   /* If true, multiple table rows can be selected.
   CTRL/CMD+Click and SHIFT+Click are valid actions.
   The default value is false.*/
-  multiSelectable:     js.UndefOr[Boolean]                                   = js.undefined,
+  multiSelectable:      js.UndefOr[Boolean]                                   = js.undefined,
   /* Callback function for when a cell is clicked.*/
-  onCellClick:         js.UndefOr[(ReactEvent, RowId, ColumnId) => Callback] = js.undefined,
+  onCellClick:          js.UndefOr[(ReactEvent, RowId, ColumnId) => Callback] = js.undefined,
   /* Called when a table cell is hovered. rowNumber
   is the row number of the hovered row and columnId
   is the column number or the column key of the cell.*/
-  onCellHover:         js.UndefOr[(ReactEvent, RowId, ColumnId) => Callback] = js.undefined,
+  onCellHover:          js.UndefOr[(ReactEvent, RowId, ColumnId) => Callback] = js.undefined,
   /* Called when a table cell is no longer hovered.
   rowNumber is the row number of the row and columnId
   is the column number or the column key of the cell.*/
-  onCellHoverExit:     js.UndefOr[(ReactEvent, RowId, ColumnId) => Callback] = js.undefined,
+  onCellHoverExit:      js.UndefOr[(ReactEvent, RowId, ColumnId) => Callback] = js.undefined,
   /* Called when a table row is hovered.
   rowNumber is the row number of the hovered row.*/
-  onRowHover:          js.UndefOr[(ReactEvent, RowId) => Callback]           = js.undefined,
+  onRowHover:           js.UndefOr[(ReactEvent, RowId) => Callback]           = js.undefined,
   /* Called when a table row is no longer
   hovered. rowNumber is the row number of the row
   that is no longer hovered.*/
-  onRowHoverExit:      js.UndefOr[RowId => Callback]                         = js.undefined,
+  onRowHoverExit:       js.UndefOr[RowId => Callback]                         = js.undefined,
   /* Called when a row is selected. selectedRows is an
   array of all row selections. IF all rows have been selected,
   the string "all" will be returned instead to indicate that
   all rows have been selected.*/
-  onRowSelection:      js.UndefOr[String | js.Array[RowId] => Callback]      = js.undefined,
+  onRowSelection:       js.UndefOr[String | js.Array[RowId] => Callback]      = js.undefined,
   /* Controls whether or not the rows are pre-scanned to determine
   initial state. If your table has a large number of rows and
   you are experiencing a delay in rendering, turn off this property.*/
-  preScanRows:         js.UndefOr[Boolean]                                   = js.undefined,
+  preScanRows:          js.UndefOr[Boolean]                                   = js.undefined,
   /* If true, table rows can be selected. If multiple
   row selection is desired, enable multiSelectable.
   The default value is true.*/
-  selectable:          js.UndefOr[Boolean]                                   = js.undefined,
+  selectable:           js.UndefOr[Boolean]                                   = js.undefined,
   /* If true, table rows will be highlighted when
   the cursor is hovering over the row. The default
   value is false.*/
-  showRowHover:        js.UndefOr[Boolean]                                   = js.undefined,
+  showRowHover:         js.UndefOr[Boolean]                                   = js.undefined,
   /* If true, every other table row starting
   with the first row will be striped. The default value is false.*/
-  stripedRows:         js.UndefOr[Boolean]                                   = js.undefined,
+  stripedRows:          js.UndefOr[Boolean]                                   = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:               js.UndefOr[CssProperties]                             = js.undefined){
+  style:                js.UndefOr[CssProperties]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]                 = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]                   = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]              = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]              = js.undefined){
   /**
    * @param children Children passed to table body.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableFooter.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableFooter.scala
@@ -8,19 +8,101 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiTableFooter(
-  key:               js.UndefOr[String]        = js.undefined,
-  ref:               js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* Controls whether or not header rows should be adjusted
   for a checkbox column. If the select all checkbox is true,
   this property will not influence the number of columns.
   This is mainly useful for "super header" rows so that
   the checkbox column does not create an offset that needs
   to be accounted for manually.*/
-  adjustForCheckbox: js.UndefOr[Boolean]       = js.undefined,
+  adjustForCheckbox:    js.UndefOr[Boolean]                            = js.undefined,
   /* The css class name of the root element.*/
-  className:         js.UndefOr[String]        = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:             js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Children passed to table footer.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableHeader.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableHeader.scala
@@ -8,8 +8,8 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiTableHeader(
-  key:               js.UndefOr[String]                  = js.undefined,
-  ref:               js.UndefOr[MuiTableHeaderM => Unit] = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiTableHeaderM => Unit]            = js.undefined,
   /* Controls whether or not header rows should be
   adjusted for a checkbox column. If the select all
   checkbox is true, this property will not influence
@@ -17,21 +17,103 @@ case class MuiTableHeader(
   "super header" rows so that the checkbox column
   does not create an offset that needs to be accounted
   for manually.*/
-  adjustForCheckbox: js.UndefOr[Boolean]                 = js.undefined,
+  adjustForCheckbox:    js.UndefOr[Boolean]                            = js.undefined,
   /* The css class name of the root element.*/
-  className:         js.UndefOr[String]                  = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* Controls whether or not the select all checkbox is displayed.*/
-  displaySelectAll:  js.UndefOr[Boolean]                 = js.undefined,
+  displaySelectAll:     js.UndefOr[Boolean]                            = js.undefined,
   /* If set to true, the select all button will be interactable.
   If set to false, the button will not be interactable.
   To hide the checkbox, set displaySelectAll to false.*/
-  enableSelectAll:   js.UndefOr[Boolean]                 = js.undefined,
+  enableSelectAll:      js.UndefOr[Boolean]                            = js.undefined,
   /* Callback when select all has been checked.*/
-  onSelectAll:       js.UndefOr[Boolean => Callback]     = js.undefined,
+  onSelectAll:          js.UndefOr[Boolean => Callback]                = js.undefined,
   /* True when select all has been checked.*/
-  selectAllSelected: js.UndefOr[Boolean]                 = js.undefined,
+  selectAllSelected:    js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:             js.UndefOr[CssProperties]           = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Children passed to table header.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableHeaderColumn.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableHeaderColumn.scala
@@ -8,27 +8,107 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiTableHeaderColumn(
-  key:          js.UndefOr[String]                             = js.undefined,
-  ref:          js.UndefOr[String]                             = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* The css class name of the root element.*/
-  className:    js.UndefOr[String]                             = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* Number to identify the header row. This property
   is automatically populated when used with TableHeader.*/
-  columnNumber: js.UndefOr[Int]                                = js.undefined,
+  columnNumber:         js.UndefOr[Int]                                = js.undefined,
   /* Not used here but we need to remove it from the root element.*/
-  hoverable:    js.UndefOr[Boolean]                            = js.undefined,
-  onClick:      js.UndefOr[(ReactEvent, ColumnId) => Callback] = js.undefined,
+  hoverable:            js.UndefOr[Boolean]                            = js.undefined,
+  onClick:              js.UndefOr[(ReactEvent, ColumnId) => Callback] = js.undefined,
   /* Not used here but we need to remove it from the root element.*/
-  onHover:      js.UndefOr[Callback]                           = js.undefined,
+  onHover:              js.UndefOr[Callback]                           = js.undefined,
   /* Not used here but we need to remove it from the root element.*/
-  onHoverExit:  js.UndefOr[Callback]                           = js.undefined,
+  onHoverExit:          js.UndefOr[Callback]                           = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:        js.UndefOr[CssProperties]                      = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The string to supply to the tooltip. If not
   string is supplied no tooltip will be shown.*/
-  tooltip:      js.UndefOr[String]                             = js.undefined,
+  tooltip:              js.UndefOr[String]                             = js.undefined,
   /* Additional styling that can be applied to the tooltip.*/
-  tooltipStyle: js.UndefOr[CssProperties]                      = js.undefined){
+  tooltipStyle:         js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply(children: ReactNode*) = {
     val props = JSMacro[MuiTableHeaderColumn](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.TableHeaderColumn)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableRow.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableRow.scala
@@ -8,54 +8,136 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiTableRow(
-  key:             js.UndefOr[String]                             = js.undefined,
-  ref:             js.UndefOr[MuiTableRowM => Unit]               = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[MuiTableRowM => Unit]               = js.undefined,
   /* The css class name of the root element.*/
-  className:       js.UndefOr[String]                             = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* If true, row border will be displayed for the row.
   If false, no border will be drawn.*/
-  displayBorder:   js.UndefOr[Boolean]                            = js.undefined,
+  displayBorder:        js.UndefOr[Boolean]                            = js.undefined,
   /* Controls whether or not the row reponseds to hover events.*/
-  hoverable:       js.UndefOr[Boolean]                            = js.undefined,
+  hoverable:            js.UndefOr[Boolean]                            = js.undefined,
   /* Controls whether or not the row should be rendered as being
   hovered. This property is evaluated in addition to this.state.hovered
   and can be used to synchronize the hovered state with some other
   external events.*/
-  hovered:         js.UndefOr[Boolean]                            = js.undefined,
+  hovered:              js.UndefOr[Boolean]                            = js.undefined,
   /* Called when a row cell is clicked.
   rowNumber is the row number and columnId is
   the column number or the column key.*/
-  onCellClick:     js.UndefOr[(ReactEvent, ColumnId) => Callback] = js.undefined,
+  onCellClick:          js.UndefOr[(ReactEvent, ColumnId) => Callback] = js.undefined,
   /* Called when a table cell is hovered.
   rowNumber is the row number of the hovered row
   and columnId is the column number or the column key of the cell.*/
-  onCellHover:     js.UndefOr[(ReactEvent, ColumnId) => Callback] = js.undefined,
+  onCellHover:          js.UndefOr[(ReactEvent, ColumnId) => Callback] = js.undefined,
   /* Called when a table cell is no longer hovered.
   rowNumber is the row number of the row and columnId
   is the column number or the column key of the cell.*/
-  onCellHoverExit: js.UndefOr[(ReactEvent, ColumnId) => Callback] = js.undefined,
+  onCellHoverExit:      js.UndefOr[(ReactEvent, ColumnId) => Callback] = js.undefined,
   /* Called when row is clicked.*/
-  onRowClick:      js.UndefOr[(ReactEventH, RowId) => Callback]   = js.undefined,
+  onRowClick:           js.UndefOr[(ReactEventH, RowId) => Callback]   = js.undefined,
   /* Called when a table row is hovered.
   rowNumber is the row number of the hovered row.*/
-  onRowHover:      js.UndefOr[ReactEvent => Callback]             = js.undefined,
+  onRowHover:           js.UndefOr[ReactEvent => Callback]             = js.undefined,
   /* Called when a table row is no longer hovered.
   rowNumber is the row number of the row that is no longer hovered.*/
-  onRowHoverExit:  js.UndefOr[(ReactEvent, RowId) => Callback]    = js.undefined,
+  onRowHoverExit:       js.UndefOr[(ReactEvent, RowId) => Callback]    = js.undefined,
   /* Number to identify the row. This property is
   automatically populated when used with the TableBody component.*/
-  rowNumber:       js.UndefOr[Int]                                = js.undefined,
+  rowNumber:            js.UndefOr[Int]                                = js.undefined,
   /* If true, table rows can be selected. If multiple row
   selection is desired, enable multiSelectable.
   The default value is true.*/
-  selectable:      js.UndefOr[Boolean]                            = js.undefined,
+  selectable:           js.UndefOr[Boolean]                            = js.undefined,
   /* Indicates that a particular row is selected.
   This property can be used to programmatically select rows.*/
-  selected:        js.UndefOr[Boolean]                            = js.undefined,
+  selected:             js.UndefOr[Boolean]                            = js.undefined,
   /* Indicates whether or not the row is striped.*/
-  striped:         js.UndefOr[Boolean]                            = js.undefined,
+  striped:              js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:           js.UndefOr[CssProperties]                      = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Children passed to table row.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableRowColumn.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTableRowColumn.scala
@@ -8,21 +8,101 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiTableRowColumn(
-  key:          js.UndefOr[String]                              = js.undefined,
-  ref:          js.UndefOr[String]                              = js.undefined,
+  key:                  js.UndefOr[String]                              = js.undefined,
+  ref:                  js.UndefOr[String]                              = js.undefined,
   /* The css class name of the root element.*/
-  className:    js.UndefOr[String]                              = js.undefined,
+  className:            js.UndefOr[String]                              = js.undefined,
   /* Number to identify the header row. This property
   is automatically populated when used with TableHeader.*/
-  columnNumber: js.UndefOr[Int]                                 = js.undefined,
+  columnNumber:         js.UndefOr[Int]                                 = js.undefined,
   /* If true, this column responds to hover events.*/
-  hoverable:    js.UndefOr[Boolean]                             = js.undefined,
-  onClick:      js.UndefOr[(ReactEvent, ColumnId) => Callback]  = js.undefined,
-  onHover:      js.UndefOr[(ReactEventH, ColumnId) => Callback] = js.undefined,
+  hoverable:            js.UndefOr[Boolean]                             = js.undefined,
+  onClick:              js.UndefOr[(ReactEvent, ColumnId) => Callback]  = js.undefined,
+  onHover:              js.UndefOr[(ReactEventH, ColumnId) => Callback] = js.undefined,
   /* Callback function for hover exit event.*/
-  onHoverExit:  js.UndefOr[(ReactEventH, ColumnId) => Callback] = js.undefined,
+  onHoverExit:          js.UndefOr[(ReactEventH, ColumnId) => Callback] = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:        js.UndefOr[CssProperties]                       = js.undefined){
+  style:                js.UndefOr[CssProperties]                       = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]             = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]             = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback]  = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback]  = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback]  = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]             = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]     = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]     = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]     = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]     = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]             = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]        = js.undefined){
   def apply(children: ReactNode*) = {
     val props = JSMacro[MuiTableRowColumn](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.TableRowColumn)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTabs.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTabs.scala
@@ -32,7 +32,87 @@ case class MuiTabs[T](
   /* Override the default tab template used to wrap the content of each tab element.*/
   tabTemplate:               js.UndefOr[js.Any]                                     = js.undefined,
   /* Makes Tabs controllable and selects the tab whose value prop matches this prop.*/
-  value:                     js.UndefOr[T]                                          = js.undefined){
+  value:                     js.UndefOr[T]                                          = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:            js.UndefOr[ReactEventH => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:      js.UndefOr[ReactEventH => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:          js.UndefOr[ReactEventH => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:                    js.UndefOr[ReactFocusEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                   js.UndefOr[ReactMouseEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:          js.UndefOr[ReactCompositionEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:        js.UndefOr[ReactCompositionEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:       js.UndefOr[ReactCompositionEventH => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:             js.UndefOr[ReactEventH => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                    js.UndefOr[ReactClipboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                     js.UndefOr[ReactClipboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:             js.UndefOr[ReactMouseEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                    js.UndefOr[ReactDragEventH => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:                 js.UndefOr[ReactDragEventH => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:               js.UndefOr[ReactDragEventH => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:                js.UndefOr[ReactDragEventH => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:               js.UndefOr[ReactDragEventH => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:                js.UndefOr[ReactDragEventH => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:               js.UndefOr[ReactDragEventH => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                    js.UndefOr[ReactDragEventH => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:                   js.UndefOr[ReactFocusEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                   js.UndefOr[ReactKeyboardEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:                 js.UndefOr[ReactKeyboardEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:                js.UndefOr[ReactKeyboardEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                   js.UndefOr[ReactKeyboardEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:               js.UndefOr[ReactMouseEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:              js.UndefOr[ReactMouseEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:              js.UndefOr[ReactMouseEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:               js.UndefOr[ReactMouseEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:                 js.UndefOr[ReactMouseEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                   js.UndefOr[ReactClipboardEventH => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                  js.UndefOr[ReactUIEventH => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                  js.UndefOr[ReactUIEventH => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                  js.UndefOr[ReactEventH => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:             js.UndefOr[ReactTouchEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:                js.UndefOr[ReactTouchEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:               js.UndefOr[ReactTouchEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:              js.UndefOr[ReactTouchEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:           js.UndefOr[ReactTouchEventH => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                   js.UndefOr[ReactWheelEventH => Callback]               = js.undefined){
   /**
    * @param children Should be used to pass `Tab` components.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTextField.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTextField.scala
@@ -8,83 +8,157 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiTextField(
-  key:                     js.UndefOr[String]                          = js.undefined,
-  ref:                     js.UndefOr[MuiTextFieldM => Unit]           = js.undefined,
+  key:                     js.UndefOr[String]                             = js.undefined,
+  ref:                     js.UndefOr[MuiTextFieldM => Unit]              = js.undefined,
   /* The css class name of the root element.*/
-  className:               js.UndefOr[String]                          = js.undefined,
+  className:               js.UndefOr[String]                             = js.undefined,
   /* The text string to use for the default value.*/
-  defaultValue:            js.UndefOr[String]                          = js.undefined,
+  defaultValue:            js.UndefOr[String]                             = js.undefined,
   /* Disables the text field if set to true.*/
-  disabled:                js.UndefOr[Boolean]                         = js.undefined,
+  disabled:                js.UndefOr[Boolean]                            = js.undefined,
   /* The style object to use to override error styles.*/
-  errorStyle:              js.UndefOr[CssProperties]                   = js.undefined,
+  errorStyle:              js.UndefOr[CssProperties]                      = js.undefined,
   /* The error content to display.*/
-  errorText:               js.UndefOr[ReactNode]                       = js.undefined,
+  errorText:               js.UndefOr[ReactNode]                          = js.undefined,
   /* If true, the floating label will float even when there is no value.*/
-  floatingLabelFixed:      js.UndefOr[Boolean]                         = js.undefined,
+  floatingLabelFixed:      js.UndefOr[Boolean]                            = js.undefined,
   /* The style object to use to override floating label styles when focused.*/
-  floatingLabelFocusStyle: js.UndefOr[CssProperties]                   = js.undefined,
+  floatingLabelFocusStyle: js.UndefOr[CssProperties]                      = js.undefined,
   /* The style object to use to override floating label styles.*/
-  floatingLabelStyle:      js.UndefOr[CssProperties]                   = js.undefined,
+  floatingLabelStyle:      js.UndefOr[CssProperties]                      = js.undefined,
   /* The content to use for the floating label element.*/
-  floatingLabelText:       js.UndefOr[ReactNode]                       = js.undefined,
+  floatingLabelText:       js.UndefOr[ReactNode]                          = js.undefined,
   /* If true, the field receives the property width 100%.*/
-  fullWidth:               js.UndefOr[Boolean]                         = js.undefined,
+  fullWidth:               js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the TextField's hint text element.*/
-  hintStyle:               js.UndefOr[CssProperties]                   = js.undefined,
+  hintStyle:               js.UndefOr[CssProperties]                      = js.undefined,
   /* The hint content to display.*/
-  hintText:                js.UndefOr[ReactNode]                       = js.undefined,
+  hintText:                js.UndefOr[ReactNode]                          = js.undefined,
   /* The id prop for the text field.*/
-  id:                      js.UndefOr[String]                          = js.undefined,
+  id:                      js.UndefOr[String]                             = js.undefined,
   /* Override the inline-styles of the TextField's input element.
   When multiLine is false: define the style of the input element.
   When multiLine is true: define the style of the container of the textarea.*/
-  inputStyle:              js.UndefOr[CssProperties]                   = js.undefined,
+  inputStyle:              js.UndefOr[CssProperties]                      = js.undefined,
   /* If true, a textarea element will be rendered.
   The textarea also grows and shrinks according to the number of lines.*/
-  multiLine:               js.UndefOr[Boolean]                         = js.undefined,
+  multiLine:               js.UndefOr[Boolean]                            = js.undefined,
   /* Name applied to the input.*/
-  name:                    js.UndefOr[String]                          = js.undefined,
-  onBlur:                  js.UndefOr[ReactEventI => Callback]         = js.undefined,
+  name:                    js.UndefOr[String]                             = js.undefined,
+  onBlur:                  js.UndefOr[ReactEventI => Callback]            = js.undefined,
   /* Callback function that is fired when the textfield's value changes.*/
-  onChange:                js.UndefOr[ReactEventI => Callback]         = js.undefined,
+  onChange:                js.UndefOr[ReactEventI => Callback]            = js.undefined,
   /* The function to call when the user presses the Enter key.*/
   @deprecated("Use onKeyDown and check for keycode instead. It will be removed with v0.16.0.")
-  onEnterKeyDown:          js.UndefOr[ReactKeyboardEventI => Callback] = js.undefined,
-  onFocus:                 js.UndefOr[ReactFocusEventI => Callback]    = js.undefined,
-  onKeyDown:               js.UndefOr[ReactKeyboardEventI => Callback] = js.undefined,
+  onEnterKeyDown:          js.UndefOr[ReactKeyboardEventI => Callback]    = js.undefined,
+  onFocus:                 js.UndefOr[ReactFocusEventI => Callback]       = js.undefined,
+  onKeyDown:               js.UndefOr[ReactKeyboardEventI => Callback]    = js.undefined,
   /* Number of rows to display when multiLine option is set to true.*/
-  rows:                    js.UndefOr[Int]                             = js.undefined,
+  rows:                    js.UndefOr[Int]                                = js.undefined,
   /* Maximum number of rows to display when
   multiLine option is set to true.*/
-  rowsMax:                 js.UndefOr[Int]                             = js.undefined,
+  rowsMax:                 js.UndefOr[Int]                                = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:                   js.UndefOr[CssProperties]                   = js.undefined,
+  style:                   js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the TextField's textarea element.
   The TextField use either a textarea or an input,
   this property has effects only when multiLine is true.*/
-  textareaStyle:           js.UndefOr[CssProperties]                   = js.undefined,
+  textareaStyle:           js.UndefOr[CssProperties]                      = js.undefined,
   /* Specifies the type of input to display
   such as "password" or "text".*/
-  `type`:                  js.UndefOr[String]                          = js.undefined,
+  `type`:                  js.UndefOr[String]                             = js.undefined,
   /* Override the inline-styles of the
   TextField's underline element when disabled.*/
-  underlineDisabledStyle:  js.UndefOr[CssProperties]                   = js.undefined,
+  underlineDisabledStyle:  js.UndefOr[CssProperties]                      = js.undefined,
   /* Override the inline-styles of the TextField's
   underline element when focussed.*/
-  underlineFocusStyle:     js.UndefOr[CssProperties]                   = js.undefined,
+  underlineFocusStyle:     js.UndefOr[CssProperties]                      = js.undefined,
   /* If true, shows the underline for the text field.*/
-  underlineShow:           js.UndefOr[Boolean]                         = js.undefined,
+  underlineShow:           js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the TextField's underline element.*/
-  underlineStyle:          js.UndefOr[CssProperties]                   = js.undefined,
+  underlineStyle:          js.UndefOr[CssProperties]                      = js.undefined,
   /* The value of the text field.*/
-  value:                   js.UndefOr[String]                          = js.undefined,
+  value:                   js.UndefOr[String]                             = js.undefined,
   /* (Passed on to EnhancedTextarea)*/
-  onHeightChange:          js.UndefOr[(ReactEvent, Int)=> Callback]    = js.undefined,
+  onHeightChange:          js.UndefOr[(ReactEvent, Int)=> Callback]       = js.undefined,
   /* (Passed on to EnhancedTextarea)*/
-  shadowStyle:             js.UndefOr[CssProperties]                   = js.undefined,
+  shadowStyle:             js.UndefOr[CssProperties]                      = js.undefined,
   /* (Passed on to EnhancedTextarea)*/
-  valueLink:               js.UndefOr[js.Any]                          = js.undefined){
+  valueLink:               js.UndefOr[js.Any]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:          js.UndefOr[ReactEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:    js.UndefOr[ReactEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:        js.UndefOr[ReactEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                 js.UndefOr[ReactMouseEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:        js.UndefOr[ReactCompositionEventI => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:      js.UndefOr[ReactCompositionEventI => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:     js.UndefOr[ReactCompositionEventI => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:           js.UndefOr[ReactEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                  js.UndefOr[ReactClipboardEventI => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                   js.UndefOr[ReactClipboardEventI => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:           js.UndefOr[ReactMouseEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                  js.UndefOr[ReactDragEventI => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:               js.UndefOr[ReactDragEventI => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:             js.UndefOr[ReactDragEventI => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:              js.UndefOr[ReactDragEventI => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:             js.UndefOr[ReactDragEventI => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:              js.UndefOr[ReactDragEventI => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:             js.UndefOr[ReactDragEventI => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                  js.UndefOr[ReactDragEventI => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                 js.UndefOr[ReactKeyboardEventI => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:              js.UndefOr[ReactKeyboardEventI => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                 js.UndefOr[ReactKeyboardEventI => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:             js.UndefOr[ReactMouseEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:            js.UndefOr[ReactMouseEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:            js.UndefOr[ReactMouseEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:             js.UndefOr[ReactMouseEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:               js.UndefOr[ReactMouseEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                 js.UndefOr[ReactClipboardEventI => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                js.UndefOr[ReactUIEventI => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                js.UndefOr[ReactUIEventI => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                js.UndefOr[ReactEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:           js.UndefOr[ReactTouchEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:              js.UndefOr[ReactTouchEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:             js.UndefOr[ReactTouchEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:            js.UndefOr[ReactTouchEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:         js.UndefOr[ReactTouchEventI => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                 js.UndefOr[ReactWheelEventI => Callback]       = js.undefined){
   def apply(children: ReactNode*) = {
     val props = JSMacro[MuiTextField](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.TextField)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTimePicker.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiTimePicker.scala
@@ -136,7 +136,81 @@ case class MuiTimePicker(
   underlineShow:           js.UndefOr[Boolean]                                    = js.undefined,
   /* Override the inline-styles of the TextField's underline element.
   (Passed on to TextField)*/
-  underlineStyle:          js.UndefOr[CssProperties]                              = js.undefined){
+  underlineStyle:          js.UndefOr[CssProperties]                              = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:          js.UndefOr[ReactEventI => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration:    js.UndefOr[ReactEventI => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:        js.UndefOr[ReactEventI => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:                 js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:        js.UndefOr[ReactCompositionEventI => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:      js.UndefOr[ReactCompositionEventI => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:     js.UndefOr[ReactCompositionEventI => Callback]         = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:           js.UndefOr[ReactEventI => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:                  js.UndefOr[ReactClipboardEventI => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                   js.UndefOr[ReactClipboardEventI => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:           js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:                  js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:               js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:             js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:              js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:             js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:              js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:             js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:                  js.UndefOr[ReactDragEventI => Callback]                = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:                 js.UndefOr[ReactKeyboardEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:              js.UndefOr[ReactKeyboardEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:                 js.UndefOr[ReactKeyboardEventI => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:             js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:            js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:            js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:             js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:               js.UndefOr[ReactMouseEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:                 js.UndefOr[ReactClipboardEventI => Callback]           = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:                js.UndefOr[ReactUIEventI => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:                js.UndefOr[ReactUIEventI => Callback]                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:                js.UndefOr[ReactEventI => Callback]                    = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:           js.UndefOr[ReactTouchEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:              js.UndefOr[ReactTouchEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:             js.UndefOr[ReactTouchEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:            js.UndefOr[ReactTouchEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:         js.UndefOr[ReactTouchEventI => Callback]               = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:                 js.UndefOr[ReactWheelEventI => Callback]               = js.undefined){
   def apply(children: ReactNode*) = {
     val props = JSMacro[MuiTimePicker](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.TimePicker)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiToggle.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiToggle.scala
@@ -82,7 +82,75 @@ case class MuiToggle[T](
   /* (Passed on to EnhancedSwitch)*/
   switched:             js.UndefOr[Boolean]                            = js.undefined,
   /* (Passed on to EnhancedSwitch)*/
-  value:                js.UndefOr[T]                                  = js.undefined){
+  value:                js.UndefOr[T]                                  = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     implicit def evT(t: T): js.Any = t.asInstanceOf[js.Any]
     val props = JSMacro[MuiToggle[T]](this)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiToolbar.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiToolbar.scala
@@ -8,14 +8,96 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiToolbar(
-  key:       js.UndefOr[String]        = js.undefined,
-  ref:       js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* The css class name of the root element.*/
-  className: js.UndefOr[String]        = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* Do not apply `desktopGutter` to the `Toolbar`.*/
-  noGutter:  js.UndefOr[Boolean]       = js.undefined,
+  noGutter:             js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:     js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be a `ToolbarGroup` to render a group of related items.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiToolbarGroup.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiToolbarGroup.scala
@@ -8,18 +8,100 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiToolbarGroup(
-  key:        js.UndefOr[String]        = js.undefined,
-  ref:        js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* The css class name of the root element.*/
-  className:  js.UndefOr[String]        = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* Set this to true for if the `ToolbarGroup` is the first child of `Toolbar`
   to prevent setting the left gap.*/
-  firstChild: js.UndefOr[Boolean]       = js.undefined,
+  firstChild:           js.UndefOr[Boolean]                            = js.undefined,
   /* Set this to true for if the `ToolbarGroup` is the last child of `Toolbar`
   to prevent setting the right gap.*/
-  lastChild:  js.UndefOr[Boolean]       = js.undefined,
+  lastChild:            js.UndefOr[Boolean]                            = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:      js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   /**
    * @param children Can be any node or number of nodes.
    */

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiToolbarSeparator.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiToolbarSeparator.scala
@@ -8,12 +8,94 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiToolbarSeparator(
-  key:       js.UndefOr[String]        = js.undefined,
-  ref:       js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* The css class name of the root element.*/
-  className: js.UndefOr[String]        = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:     js.UndefOr[CssProperties] = js.undefined){
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     val props = JSMacro[MuiToolbarSeparator](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.ToolbarSeparator)

--- a/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiToolbarTitle.scala
+++ b/core/src/main/scala/chandu0101/scalajs/react/components/materialui/MuiToolbarTitle.scala
@@ -8,14 +8,96 @@ import scala.scalajs.js.`|`
  * This file is generated - submit issues instead of PR against it
  */
 case class MuiToolbarTitle(
-  key:       js.UndefOr[String]        = js.undefined,
-  ref:       js.UndefOr[String]        = js.undefined,
+  key:                  js.UndefOr[String]                             = js.undefined,
+  ref:                  js.UndefOr[String]                             = js.undefined,
   /* The css class name of the root element.*/
-  className: js.UndefOr[String]        = js.undefined,
+  className:            js.UndefOr[String]                             = js.undefined,
   /* Override the inline-styles of the root element.*/
-  style:     js.UndefOr[CssProperties] = js.undefined,
+  style:                js.UndefOr[CssProperties]                      = js.undefined,
   /* The text to be displayed.*/
-  text:      js.UndefOr[String]        = js.undefined){
+  text:                 js.UndefOr[String]                             = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationEnd:       js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationIteration: js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onAnimationStart:     js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onBlur:               js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onChange:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onClick:              js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionEnd:     js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionStart:   js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onCompositionUpdate:  js.UndefOr[ReactCompositionEventH => Callback] = js.undefined,
+  /* (Passed on to DOM)*/
+  onContextMenu:        js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onCopy:               js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onCut:                js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onDoubleClick:        js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrag:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnd:            js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragEnter:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragExit:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragLeave:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragOver:           js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDragStart:          js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onDrop:               js.UndefOr[ReactDragEventH => Callback]        = js.undefined,
+  /* (Passed on to DOM)*/
+  onFocus:              js.UndefOr[ReactFocusEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onInput:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyDown:            js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyPress:           js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onKeyUp:              js.UndefOr[ReactKeyboardEventH => Callback]    = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseDown:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseEnter:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseLeave:         js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseMove:          js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onMouseUp:            js.UndefOr[ReactMouseEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onPaste:              js.UndefOr[ReactClipboardEventH => Callback]   = js.undefined,
+  /* (Passed on to DOM)*/
+  onScroll:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSelect:             js.UndefOr[ReactUIEventH => Callback]          = js.undefined,
+  /* (Passed on to DOM)*/
+  onSubmit:             js.UndefOr[ReactEventH => Callback]            = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchCancel:        js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchEnd:           js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchMove:          js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTouchStart:         js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onTransitionEnd:      js.UndefOr[ReactTouchEventH => Callback]       = js.undefined,
+  /* (Passed on to DOM)*/
+  onWheel:              js.UndefOr[ReactWheelEventH => Callback]       = js.undefined){
   def apply() = {
     val props = JSMacro[MuiToolbarTitle](this)
     val f = React.asInstanceOf[js.Dynamic].createFactory(Mui.ToolbarTitle)


### PR DESCRIPTION
So, material-ui follows the (rather braindead) javascript pattern of threading through all other props it doesnt know about further to the dom element it uses to actually render a component. 

Most of these callbacks are not correctly exposed in components' propTypes, and might be useful. Should we add something like this? it _massively_ clutters up things.

Any input, @chandu0101 ? We should really have some other, more composable encoding of components!
